### PR TITLE
add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,50 @@
+---
+name: Bug report
+about: "Something isn't working as expected? Report it here \U0001F917"
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Description
+
+<!--
+    Describe the problem you are experiencing.
+-->
+
+
+### Steps to reproduce 🔢
+
+<!--
+    What are the minimal set of steps required to reproduce the issue?
+-->
+
+1. ...
+2. ...
+3. ...
+
+### Expected result ✅
+
+<!--
+    What should happen?
+-->
+
+
+### Actual result ❌
+
+<!--
+    What happened?
+-->
+
+
+### Environment ⚙️
+
+<!--
+    Tell us about your setup
+-->
+
+* OS:
+* Arch:
+* Rust (run `rustc --version`):
+* Cargo (run `cargo version`):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: Feature request
+about: Suggest a new idea for the project ✨
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Description
+
+<!--
+    Brief explanation of the feature.
+-->
+
+
+### Example 🗺️
+
+<!--
+    If the proposal involves a new or changed API, please include a basic code example. Omit this section if it's not applicable.
+-->
+
+
+### Motivation 💪
+
+<!--
+    Why is this helpful? What use cases does it enable?
+-->
+

--- a/.github/ISSUE_TEMPLATE/question-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/question-issue-template.md
@@ -1,0 +1,33 @@
+---
+name: Question issue template
+about: "Have a question about the workspace or any of its crate? Ask here \U0001F64B"
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Summary
+
+<!--
+	What's your question?
+-->
+
+### Details / Background Info 🚨
+
+<!--
+	Please share any relevant technical detail and / or edge-cases we should know about
+-->
+
+
+### Environment (if relevant) ⚙️
+
+<!--
+    Tell us about your setup
+-->
+
+* OS:
+* Arch:
+* Rust (run `rustc --version`):
+* Cargo (run `cargo version`):
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,43 @@
+## Description
+
+<!--
+	Please write a brief description of the changes introduced by this PR: What issues(s) does it address? How does it solve them? For ui-centric changes, please include a screenshot or video.
+-->
+
+
+## How to Test
+
+<!--
+	What steps can a reviewer take to manually test your changes?
+-->
+
+1.
+2.
+3.
+
+**Outcome**
+
+<!--
+	What should a reviewer expect to happen in order to confirm your changes are working as expected?
+-->
+
+
+## Related / Discussions
+
+<!--
+	Link to related PRs or Issues
+	e.g. https://github.com/busticated/rusty/pull/1
+
+	Link to any relevant community discussions
+	e.g. As discussed here: https://users.rust-lang.org/<path-to-topic>
+-->
+
+
+## Completeness
+
+- [x] PR opened :tada:
+- [ ] Testing instructions have been provided
+- [ ] Development [How-To's](https://github.com/busticated/rusty#development) have been provided
+- [ ] Docs have been updated (`cargo xtask doc`)
+- [ ] Branch is rebased against _target_ (typically `main`)
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,10 @@ name: Run CI/CD Jobs
 
 on:
   push:
+    paths:
+      - ".github/workflows/**.yml"
+      - "**/Cargo.toml"
+      - "**.rs"
   schedule:
     - cron: '0 16 * * WED'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,8 +6,7 @@ on:
       - ".github/workflows/**.yml"
       - "**/Cargo.toml"
       - "**.rs"
-  schedule:
-    - cron: '0 16 * * WED'
+  workflow_dispatch:
 
 jobs:
   test:

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -250,7 +250,7 @@ fn init_tasks() -> Tasks {
                 let krates = workspace.krates()?;
 
                 for krate in krates.values() {
-                    println!("* {}: {}", krate.name, krate.path.display());
+                    println!("* {}: {} [{}]\n  >> {}\n", krate.name, krate.description, krate.kind, krate.path.display());
                 }
 
                 println!();

--- a/xtask/src/tasks.rs
+++ b/xtask/src/tasks.rs
@@ -80,14 +80,14 @@ impl Tasks {
         for task in self.map.values() {
             let char_count = task.name.char_indices().count();
             let spaces = separator.repeat(max_col_width - char_count + padding);
-            let line = format!("> {}{}{}\n", task.name, spaces, task.description);
+            let line = format!(">> {}{}{}\n", task.name, spaces, task.description);
 
             lines.push_str(&line);
 
             for (name, description) in task.flags.iter() {
                 let separator = " ".to_string();
                 let spaces = separator.repeat(max_col_width + padding);
-                let line = format!("\n{}  > --{} | {}\n", spaces, name, description);
+                let line = format!("\n{}   >> --{} | {}\n", spaces, name, description);
                 lines.push_str(&line);
             }
 
@@ -181,15 +181,15 @@ mod tests {
         assert_eq!(
             tasks.help().unwrap(),
             [
-                "> one....task 01",
+                ">> one....task 01",
                 "",
-                "         > --bar | enables bar",
+                "          >> --bar | enables bar",
                 "",
-                "         > --foo | does the foo",
+                "          >> --foo | does the foo",
                 "",
-                "> two....task 02",
+                ">> two....task 02",
                 "",
-                "         > --baz | invokes a baz",
+                "          >> --baz | invokes a baz",
                 "",
                 "",
             ]


### PR DESCRIPTION
## Description

Adds Github issue and PR templates, tunes CI triggers, and cleans up some task bits. 


## How to Test

1. Clone and setup this branch locally ([docs](https://github.com/busticated/rusty#installation))
2. Review new templates: [PR](https://github.com/busticated/rusty/blob/5943a49f6b81b1835a9607045b2c99374e8b3474/.github/pull_request_template.md), [Issues](https://github.com/busticated/rusty/tree/5943a49f6b81b1835a9607045b2c99374e8b3474/.github/ISSUE_TEMPLATE)
3. Try out some development tasks - e.g. `cargo xtask --help` ([docs](https://github.com/busticated/rusty#development))

**Outcome**

Local dev setup should work 🎉, tasks should run successfully 🎊, code should make sense 🤗 


## Related / Discussions

https://github.com/busticated/rusty/pull/1


## Completeness

- [x] PR opened :tada:
- [x] Testing instructions have been provided
- [x] Development [How-To's](https://github.com/busticated/rusty#development) have been provided
- [x] Docs have been updated (`cargo xtask doc`)
- [x] Branch is rebased against _target_ (typically `main`)

