### PR TITLE
chore/cleanups

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,10 @@ name: Run CI/CD Jobs
 
 on:
   push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
     paths:
       - ".github/workflows/**.yml"
       - "**/Cargo.toml"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
 # see: https://rust-lang.github.io/rustfmt/
-reorder_modules = false
-reorder_imports = false
+#
+# reorder_modules = false
+# reorder_imports = false

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -1,10 +1,10 @@
 use crate::options::Options;
 use duct::{cmd, Expression};
-use std::ffi::OsString;
 use std::collections::HashMap;
-use std::path::PathBuf;
-use std::error::Error;
 use std::env;
+use std::error::Error;
+use std::ffi::OsString;
+use std::path::PathBuf;
 
 type DynError = Box<dyn Error>;
 

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -1,0 +1,385 @@
+use crate::options::Options;
+use duct::{cmd, Expression};
+use std::ffi::OsString;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::error::Error;
+use std::env;
+
+type DynError = Box<dyn Error>;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Cargo<'a> {
+    pub bin: String,
+    opts: &'a Options,
+}
+
+impl<'a> Cargo<'a> {
+    pub fn new(opts: &'a Options) -> Cargo<'a> {
+        let bin = env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+        Cargo { bin, opts }
+    }
+
+    fn exec_safe(&self, args: Vec<OsString>, envs: HashMap<OsString, OsString>) -> Expression {
+        if envs.is_empty() {
+            return cmd(&self.bin, args);
+        }
+
+        let mut exp = cmd(&self.bin, args);
+
+        for (key, value) in envs.iter() {
+            exp = exp.env(key, value);
+        }
+
+        exp
+    }
+
+    fn exec_unsafe(&self, args: Vec<OsString>, envs: HashMap<OsString, OsString>) -> Expression {
+        if self.opts.has("dry-run") {
+            let mut args = args.clone();
+            args.insert(0, "skipping:".into());
+            args.insert(1, "cargo".into());
+            // TODO (busticated): windows? see: https://stackoverflow.com/a/61857874/579167
+            return cmd("echo", args);
+        }
+
+        self.exec_safe(args, envs)
+    }
+
+    fn build_args<U, UU>(&self, args1: U, args2: UU) -> Vec<OsString>
+    where
+        U: IntoIterator,
+        U::Item: Into<OsString>,
+        UU: IntoIterator,
+        UU::Item: Into<OsString>,
+    {
+        let mut args = args1
+            .into_iter()
+            .map(Into::<OsString>::into)
+            .collect::<Vec<_>>();
+
+        args.extend(
+            args2
+                .into_iter()
+                .map(Into::<OsString>::into)
+                .collect::<Vec<_>>(),
+        );
+
+        args.retain(|a| !a.is_empty());
+        args
+    }
+
+    pub fn workspace_path(&self) -> Result<PathBuf, DynError> {
+        let (args, envs) = self.workspace_path_params();
+        let stdout = self.exec_safe(args, envs).read()?;
+        Ok(PathBuf::from(stdout.replace("Cargo.toml", "").trim()))
+    }
+
+    fn workspace_path_params(&self) -> (Vec<OsString>, HashMap<OsString, OsString>) {
+        let args = self.build_args(
+            ["locate-project", "--workspace", "--message-format", "plain"],
+            [""],
+        );
+        (args, HashMap::new())
+    }
+
+    pub fn create<P, U>(&self, path: P, arguments: U) -> Expression
+    where
+        P: Into<OsString>,
+        U: IntoIterator,
+        U::Item: Into<OsString>,
+    {
+        let (args, envs) = self.create_params(path, arguments);
+        self.exec_unsafe(args, envs)
+    }
+
+    fn create_params<P, U>(
+        &self,
+        path: P,
+        arguments: U,
+    ) -> (Vec<OsString>, HashMap<OsString, OsString>)
+    where
+        P: Into<OsString>,
+        U: IntoIterator,
+        U::Item: Into<OsString>,
+    {
+        let args = self.build_args(["new".into(), path.into()], arguments);
+        (args, HashMap::new())
+    }
+
+    pub fn install<U>(&self, arguments: U) -> Expression
+    where
+        U: IntoIterator,
+        U::Item: Into<OsString>,
+    {
+        let (args, envs) = self.install_params(arguments);
+        self.exec_unsafe(args, envs)
+    }
+
+    fn install_params<U>(&self, arguments: U) -> (Vec<OsString>, HashMap<OsString, OsString>)
+    where
+        U: IntoIterator,
+        U::Item: Into<OsString>,
+    {
+        let args = self.build_args([OsString::from("install")], arguments);
+        (args, HashMap::new())
+    }
+
+    pub fn build<U>(&self, arguments: U) -> Expression
+    where
+        U: IntoIterator,
+        U::Item: Into<OsString>,
+    {
+        let (args, envs) = self.build_params(arguments);
+        self.exec_safe(args, envs)
+    }
+
+    fn build_params<U>(&self, arguments: U) -> (Vec<OsString>, HashMap<OsString, OsString>)
+    where
+        U: IntoIterator,
+        U::Item: Into<OsString>,
+    {
+        let args = self.build_args([OsString::from("build")], arguments);
+        (args, HashMap::new())
+    }
+
+    pub fn clean<U>(&self, arguments: U) -> Expression
+    where
+        U: IntoIterator,
+        U::Item: Into<OsString>,
+    {
+        let (args, envs) = self.clean_params(arguments);
+        self.exec_unsafe(args, envs)
+    }
+
+    fn clean_params<U>(&self, arguments: U) -> (Vec<OsString>, HashMap<OsString, OsString>)
+    where
+        U: IntoIterator,
+        U::Item: Into<OsString>,
+    {
+        let args = self.build_args([OsString::from("clean")], arguments);
+        (args, HashMap::new())
+    }
+
+    pub fn test<U>(&self, arguments: U) -> Expression
+    where
+        U: IntoIterator,
+        U::Item: Into<OsString>,
+    {
+        let (args, envs) = self.test_params(arguments);
+        self.exec_safe(args, envs)
+    }
+
+    fn test_params<U>(&self, arguments: U) -> (Vec<OsString>, HashMap<OsString, OsString>)
+    where
+        U: IntoIterator,
+        U::Item: Into<OsString>,
+    {
+        let args = self.build_args([OsString::from("test")], arguments);
+        (args, HashMap::new())
+    }
+
+    pub fn coverage<P>(&self, path: P) -> Expression
+    where
+        P: Into<OsString>,
+    {
+        let (args, envs) = self.coverage_params(path);
+        self.exec_unsafe(args, envs)
+    }
+
+    fn coverage_params<P>(&self, path: P) -> (Vec<OsString>, HashMap<OsString, OsString>)
+    where
+        P: Into<OsString>,
+    {
+        let mut profile_ptn: OsString = path.into();
+        profile_ptn.push("/cargo-test-%p-%m.profraw");
+        let args = self.build_args([OsString::from("test")], [""]);
+        let envs = HashMap::from([
+            ("CARGO_INCREMENTAL".into(), "0".into()),
+            ("RUSTFLAGS".into(), "-Cinstrument-coverage".into()),
+            ("LLVM_PROFILE_FILE".into(), profile_ptn),
+        ]);
+
+        (args, envs)
+    }
+
+    pub fn lint(&self) -> Expression {
+        let (args, envs) = self.lint_params();
+        self.exec_safe(args, envs)
+    }
+
+    fn lint_params(&self) -> (Vec<OsString>, HashMap<OsString, OsString>) {
+        let args = self.build_args(
+            [OsString::from("clippy")],
+            ["--all-targets", "--all-features", "--no-deps"],
+        );
+        let envs = HashMap::from([("RUSTFLAGS".into(), "-Dwarnings".into())]);
+
+        (args, envs)
+    }
+
+    pub fn doc<U>(&self, arguments: U) -> Expression
+    where
+        U: IntoIterator,
+        U::Item: Into<OsString>,
+    {
+        let (args, envs) = self.doc_params(arguments);
+        self.exec_unsafe(args, envs)
+    }
+
+    fn doc_params<U>(&self, arguments: U) -> (Vec<OsString>, HashMap<OsString, OsString>)
+    where
+        U: IntoIterator,
+        U::Item: Into<OsString>,
+    {
+        let args = self.build_args([OsString::from("doc")], arguments);
+        (args, HashMap::new())
+    }
+
+    pub fn publish_package<N: AsRef<str>>(&self, name: N) -> Expression {
+        let (args, envs) = self.publish_package_params(name);
+        self.exec_unsafe(args, envs)
+    }
+
+    fn publish_package_params<N: AsRef<str>>(
+        &self,
+        name: N,
+    ) -> (Vec<OsString>, HashMap<OsString, OsString>) {
+        let args = self.build_args(["publish", "--package", name.as_ref()], [""]);
+        (args, HashMap::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::task_flags;
+
+    #[test]
+    fn it_initializes() {
+        let opts = Options::new(vec![], task_flags! {}).unwrap();
+        let _ = Cargo::new(&opts);
+    }
+
+    #[test]
+    fn it_builds_args() {
+        let opts = Options::new(vec![], task_flags! {}).unwrap();
+        let cargo = Cargo::new(&opts);
+        let args = cargo.build_args(["one"], ["two", "three"]);
+        assert_eq!(args, ["one", "two", "three"]);
+    }
+
+    #[test]
+    fn it_builds_args_for_getting_workspace_path() {
+        let opts = Options::new(vec![], task_flags! {}).unwrap();
+        let cargo = Cargo::new(&opts);
+        let (args, envs) = cargo.workspace_path_params();
+        assert_eq!(
+            args,
+            ["locate-project", "--workspace", "--message-format", "plain"]
+        );
+        assert_eq!(envs, HashMap::new());
+    }
+
+    #[test]
+    fn it_builds_args_for_the_create_subcommand() {
+        let opts = Options::new(vec![], task_flags! {}).unwrap();
+        let cargo = Cargo::new(&opts);
+        let path = PathBuf::from("fake-crate-path");
+        let (args, envs) = cargo.create_params(path, ["--name", "my-crate", "--lib"]);
+        assert_eq!(
+            args,
+            ["new", "fake-crate-path", "--name", "my-crate", "--lib"]
+        );
+        assert_eq!(envs, HashMap::new());
+    }
+
+    #[test]
+    fn it_builds_args_for_the_install_subcommand() {
+        let opts = Options::new(vec![], task_flags! {}).unwrap();
+        let cargo = Cargo::new(&opts);
+        let (args, envs) = cargo.install_params(["grcov"]);
+        assert_eq!(args, ["install", "grcov"]);
+        assert_eq!(envs, HashMap::new());
+    }
+
+    #[test]
+    fn it_builds_args_for_the_build_subcommand() {
+        let opts = Options::new(vec![], task_flags! {}).unwrap();
+        let cargo = Cargo::new(&opts);
+        let (args, envs) = cargo.build_params(["--release"]);
+        assert_eq!(args, ["build", "--release"]);
+        assert_eq!(envs, HashMap::new());
+    }
+
+    #[test]
+    fn it_builds_args_for_the_clean_subcommand() {
+        let opts = Options::new(vec![], task_flags! {}).unwrap();
+        let cargo = Cargo::new(&opts);
+        let (args, envs) = cargo.clean_params(["--release"]);
+        assert_eq!(args, ["clean", "--release"]);
+        assert_eq!(envs, HashMap::new());
+    }
+
+    #[test]
+    fn it_builds_args_for_the_test_subcommand() {
+        let opts = Options::new(vec![], task_flags! {}).unwrap();
+        let cargo = Cargo::new(&opts);
+        let (args, envs) = cargo.test_params(["--doc"]);
+        assert_eq!(args, ["test", "--doc"]);
+        assert_eq!(envs, HashMap::new());
+    }
+
+    #[test]
+    fn it_builds_args_for_the_coverage_subcommand() {
+        let opts = Options::new(vec![], task_flags! {}).unwrap();
+        let cargo = Cargo::new(&opts);
+        let path = PathBuf::from("fake-coverage-path");
+        let (args, envs) = cargo.coverage_params(path);
+        assert_eq!(args, ["test"]);
+        assert_eq!(
+            envs,
+            HashMap::from([
+                ("CARGO_INCREMENTAL".into(), "0".into()),
+                ("RUSTFLAGS".into(), "-Cinstrument-coverage".into()),
+                (
+                    "LLVM_PROFILE_FILE".into(),
+                    "fake-coverage-path/cargo-test-%p-%m.profraw".into()
+                ),
+            ])
+        );
+    }
+
+    #[test]
+    fn it_builds_args_for_the_lint_subcommand() {
+        let opts = Options::new(vec![], task_flags! {}).unwrap();
+        let cargo = Cargo::new(&opts);
+        let (args, envs) = cargo.lint_params();
+        assert_eq!(
+            args,
+            ["clippy", "--all-targets", "--all-features", "--no-deps"]
+        );
+        assert_eq!(
+            envs,
+            HashMap::from([("RUSTFLAGS".into(), "-Dwarnings".into()),])
+        );
+    }
+
+    #[test]
+    fn it_builds_args_for_the_doc_subcommand() {
+        let opts = Options::new(vec![], task_flags! {}).unwrap();
+        let cargo = Cargo::new(&opts);
+        let (args, envs) = cargo.doc_params(["--workspace", "--no-deps"]);
+        assert_eq!(args, ["doc", "--workspace", "--no-deps"]);
+        assert_eq!(envs, HashMap::new());
+    }
+
+    #[test]
+    fn it_builds_args_for_the_publish_package_subcommand() {
+        let opts = Options::new(vec![], task_flags! {}).unwrap();
+        let cargo = Cargo::new(&opts);
+        let (args, envs) = cargo.publish_package_params("my-crate");
+        assert_eq!(args, ["publish", "--package", "my-crate"]);
+        assert_eq!(envs, HashMap::new());
+    }
+}

--- a/xtask/src/exec.rs
+++ b/xtask/src/exec.rs
@@ -1,0 +1,100 @@
+use crate::options::Options;
+use duct::{cmd, Expression};
+use std::collections::HashMap;
+use std::ffi::OsString;
+
+pub type EnvVars = Option<HashMap<OsString, OsString>>;
+
+pub trait Execute {
+    fn bin(&self) -> String;
+
+    fn opts(&self) -> &Options;
+
+    fn exec_safe(&self, args: Vec<OsString>, envs: EnvVars) -> Expression {
+        if envs.is_none() {
+            return cmd(self.bin(), args);
+        }
+
+        let envs = envs.unwrap();
+        let mut exp = cmd(self.bin(), args);
+
+        for (key, value) in envs.iter() {
+            exp = exp.env(key, value);
+        }
+
+        exp
+    }
+
+    fn exec_unsafe(&self, args: Vec<OsString>, envs: EnvVars) -> Expression {
+        if self.opts().has("dry-run") {
+            let mut args = args.clone();
+            args.insert(0, "skipping:".into());
+            args.insert(1, self.bin().into());
+            // TODO (busticated): windows? see: https://stackoverflow.com/a/61857874/579167
+            return cmd("echo", args);
+        }
+
+        self.exec_safe(args, envs)
+    }
+
+    fn build_args<U, UU>(&self, args1: U, args2: UU) -> Vec<OsString>
+    where
+        U: IntoIterator,
+        U::Item: Into<OsString>,
+        UU: IntoIterator,
+        UU::Item: Into<OsString>,
+    {
+        let mut args = args1
+            .into_iter()
+            .map(Into::<OsString>::into)
+            .collect::<Vec<_>>();
+
+        args.extend(
+            args2
+                .into_iter()
+                .map(Into::<OsString>::into)
+                .collect::<Vec<_>>(),
+        );
+
+        args.retain(|a| !a.is_empty());
+        args
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::task_flags;
+
+    struct TestExecutable {
+        bin: String,
+        opts: Options,
+    }
+
+    impl Execute for TestExecutable {
+        fn bin(&self) -> String {
+            self.bin.to_owned()
+        }
+
+        fn opts(&self) -> &Options {
+            &self.opts
+        }
+    }
+
+    impl TestExecutable {
+        fn new(opts: Options) -> Self {
+            TestExecutable {
+                bin: "test".to_string(),
+                opts,
+            }
+        }
+    }
+
+    #[test]
+    fn it_builds_args() {
+        let opts = Options::new(vec![], task_flags! {}).unwrap();
+        let fake = TestExecutable::new(opts);
+        let args = fake.build_args(["one"], ["two", "three"]);
+        assert_eq!(args, ["one", "two", "three"]);
+    }
+}

--- a/xtask/src/fs.rs
+++ b/xtask/src/fs.rs
@@ -1,6 +1,6 @@
+use crate::options::Options;
 use std::fs;
 use std::path::Path;
-use crate::options::Options;
 
 type IOResult = std::io::Result<()>;
 

--- a/xtask/src/fs.rs
+++ b/xtask/src/fs.rs
@@ -1,0 +1,62 @@
+use std::fs;
+use std::path::Path;
+use crate::options::Options;
+
+type IOResult = std::io::Result<()>;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct FS<'a> {
+    opts: &'a Options,
+}
+
+impl<'a> FS<'a> {
+    pub fn new(opts: &'a Options) -> FS<'a> {
+        FS { opts }
+    }
+
+    pub fn write<P: AsRef<Path>, D: AsRef<[u8]>>(&self, path: P, data: D) -> IOResult {
+        if self.opts.has("dry-run") {
+            let path = path.as_ref().to_string_lossy();
+            println!("Skipping: write {}", path);
+            return Ok(());
+        }
+
+        fs::write(path, data)
+    }
+
+    pub fn remove_dir_all<P: AsRef<Path>>(&self, path: P) -> IOResult {
+        if self.opts.has("dry-run") {
+            let path = path.as_ref().to_string_lossy();
+            println!("Skipping: remove_dir_all {}", path);
+            return Ok(());
+        }
+
+        fs::remove_dir_all(path)
+    }
+
+    pub fn create_dir_all<P: AsRef<Path>>(&self, path: P) -> IOResult {
+        if self.opts.has("dry-run") {
+            let path = path.as_ref().to_string_lossy();
+            println!("Skipping: create_dir_all {}", path);
+            return Ok(());
+        }
+
+        fs::create_dir_all(path)
+    }
+
+    pub fn read_dir<P: AsRef<Path>>(&self, path: P) -> std::io::Result<fs::ReadDir> {
+        fs::read_dir(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::task_flags;
+
+    #[test]
+    fn it_initializes() {
+        let opts = Options::new(vec![], task_flags! {}).unwrap();
+        let _ = FS::new(&opts);
+    }
+}

--- a/xtask/src/git.rs
+++ b/xtask/src/git.rs
@@ -162,8 +162,8 @@ impl<'a> Git<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::Path;
     use crate::task_flags;
+    use std::path::Path;
 
     #[test]
     fn it_initializes() {

--- a/xtask/src/git.rs
+++ b/xtask/src/git.rs
@@ -19,7 +19,7 @@ impl<'a> Git<'a> {
         if self.opts.has("dry-run") {
             args.insert(0, "skipping:".into());
             args.insert(1, "git".into());
-            // TODO (mirande): windows? see: https://stackoverflow.com/a/61857874/579167
+            // TODO (busticated): windows? see: https://stackoverflow.com/a/61857874/579167
             return cmd("echo", args);
         }
 
@@ -135,15 +135,14 @@ impl<'a> Git<'a> {
     }
 
     fn todos_raw(&self) -> Vec<OsString> {
-        // so we don't include this fn in the list (x_X)
-        let mut ptn = String::from("TODO");
-        ptn.push_str(" (.*)");
+        let ptn = r"TODO\s?\(.*\)|todo!\(\)";
 
         self.build_args(
             vec![
                 "grep",
+                "-P",
                 "-e",
-                ptn.as_str(),
+                ptn,
                 "--ignore-case",
                 "--heading",
                 "--break",
@@ -223,15 +222,13 @@ mod tests {
         let opts = Options::new(vec![], task_flags! {}).unwrap();
         let git = Git::new(&opts);
         let args = git.todos_raw();
-        let starts_with = "TODO";
-        let ends_with = " (.*)";
-        assert_eq!(args[0..2], ["grep", "-e",]);
-        assert_eq!(args[2].len(), starts_with.len() + ends_with.len());
-        assert!(args[2].to_string_lossy().starts_with(starts_with));
-        assert!(args[2].to_string_lossy().ends_with(ends_with));
         assert_eq!(
-            args[3..],
+            args,
             [
+                "grep",
+                "-P",
+                "-e",
+                r"TODO\s?\(.*\)|todo!\(\)",
                 "--ignore-case",
                 "--heading",
                 "--break",

--- a/xtask/src/krate.rs
+++ b/xtask/src/krate.rs
@@ -1,8 +1,8 @@
+use crate::fs::FS;
 use crate::readme::Readme;
 use crate::toml::Toml;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
-use std::fs;
 use std::path::PathBuf;
 use std::str::FromStr;
 use semver::Version;
@@ -107,12 +107,18 @@ impl Krate {
         Ok(())
     }
 
-    pub fn clean(&self) -> Result<(), DynError> {
-        Ok(fs::remove_dir_all(self.tmp_path())?)
+    pub fn clean(&self, fs: &FS) -> Result<(), DynError> {
+        use std::io::ErrorKind;
+
+        match fs.remove_dir_all(self.tmp_path()) {
+            Err(e) if e.kind() == ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(Box::new(e)),
+            Ok(()) => Ok(()),
+        }
     }
 
-    pub fn create_dirs(&self) -> Result<(), DynError> {
-        Ok(fs::create_dir_all(self.coverage_path())?)
+    pub fn create_dirs(&self, fs: &FS) -> Result<(), DynError> {
+        Ok(fs.create_dir_all(self.coverage_path())?)
     }
 }
 

--- a/xtask/src/krate.rs
+++ b/xtask/src/krate.rs
@@ -1,11 +1,11 @@
 use crate::fs::FS;
 use crate::readme::Readme;
 use crate::toml::Toml;
+use semver::Version;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 use std::str::FromStr;
-use semver::Version;
 
 type DynError = Box<dyn Error>;
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,6 +1,6 @@
+mod cargo;
 mod fs;
 mod git;
-mod cargo;
 mod krate;
 mod options;
 mod readme;
@@ -10,11 +10,11 @@ mod toml;
 mod workspace;
 
 use crate::krate::{Krate, KratePaths};
-use crate::tasks::{Task, Tasks};
 use crate::semver::VersionChoice;
+use crate::tasks::{Task, Tasks};
 use duct::cmd;
-use inquire::required;
 use inquire::list_option::ListOption as InquireListOption;
+use inquire::required;
 use inquire::validator::Validation as InquireValidation;
 use inquire::{MultiSelect as InquireMultiSelect, Select as InquireSelect, Text as InquireText};
 use regex::RegexBuilder;
@@ -182,7 +182,6 @@ fn init_tasks() -> Tasks {
                 println!(":::: Done!");
                 println!(":::: Report: {}", report);
                 println!();
-
                 Ok(())
             },
         },
@@ -234,7 +233,6 @@ fn init_tasks() -> Tasks {
 
                 println!(":::: Done!");
                 println!();
-
                 Ok(())
             },
         },
@@ -258,7 +256,6 @@ fn init_tasks() -> Tasks {
                 println!();
                 println!(":::: Done!");
                 println!();
-
                 Ok(())
             },
         },
@@ -372,7 +369,6 @@ fn init_tasks() -> Tasks {
                 println!(":::: Done!");
                 println!(":::: Artifacts: {}", dist_dir.display());
                 println!();
-
                 Ok(())
             },
         },
@@ -420,7 +416,6 @@ fn init_tasks() -> Tasks {
 
                 println!(":::: Done!");
                 println!();
-
                 Ok(())
             },
         },
@@ -438,7 +433,6 @@ fn init_tasks() -> Tasks {
 
                 println!(":::: Done!");
                 println!();
-
                 Ok(())
             },
         },
@@ -465,7 +459,6 @@ fn init_tasks() -> Tasks {
 
                 println!(":::: Done!");
                 println!();
-
                 Ok(())
             },
         },
@@ -483,7 +476,6 @@ fn init_tasks() -> Tasks {
 
                 println!(":::: Done!");
                 println!();
-
                 Ok(())
             },
         },
@@ -501,7 +493,6 @@ fn init_tasks() -> Tasks {
 
                 println!(":::: Done!");
                 println!();
-
                 Ok(())
             },
         },

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -280,8 +280,9 @@ fn init_tasks() -> Tasks {
                 println!(":::::::::::::::::::::::::::");
                 println!();
 
+                let git = Git::new(&opts);
                 let krates = workspace.krates()?;
-                let tag_text = cmd!("git", "tag", "--points-at", "HEAD").read()?;
+                let tag_text = git.get_tags(["--points-at", "HEAD"]).read()?;
                 let mut tags = vec![];
 
                 for line in tag_text.lines() {
@@ -514,33 +515,14 @@ fn init_tasks() -> Tasks {
             name: "todo".into(),
             description: "list open to-dos based on inline source code comments".into(),
             flags: task_flags! {},
-            run: |_opts, _workspace, _tasks| {
+            run: |opts, _workspace, _tasks| {
                 println!(":::::::::::::::");
                 println!(":::: TODOs ::::");
                 println!(":::::::::::::::");
                 println!();
 
-                // so we don't include this fn in the list (x_X)
-                let mut ptn = String::from("TODO");
-                ptn.push_str(" (.*)");
-
-                cmd!(
-                    "git",
-                    "grep",
-                    "-e",
-                    ptn,
-                    "--ignore-case",
-                    "--heading",
-                    "--break",
-                    "--context",
-                    "2",
-                    "--full-name",
-                    "--line-number",
-                    "--",
-                    ":!./target/*",
-                    ":!./tmp/*",
-                )
-                .run()?;
+                let git = Git::new(&opts);
+                git.todos().run()?;
 
                 println!(":::: Done!");
                 println!();

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,4 +1,6 @@
+mod fs;
 mod git;
+mod cargo;
 mod krate;
 mod options;
 mod readme;
@@ -7,11 +9,9 @@ mod tasks;
 mod toml;
 mod workspace;
 
-use crate::git::Git;
 use crate::krate::{Krate, KratePaths};
 use crate::tasks::{Task, Tasks};
 use crate::semver::VersionChoice;
-use crate::workspace::Workspace;
 use duct::cmd;
 use inquire::required;
 use inquire::list_option::ListOption as InquireListOption;
@@ -54,13 +54,8 @@ fn try_main() -> Result<(), DynError> {
 
     let tasks = init_tasks();
     match tasks.get(cmd.clone()) {
+        Some(task) => task.exec(args, &tasks),
         None => print_help(cmd, args, tasks),
-        Some(task) => {
-            let cargo_cmd = get_cargo_cmd();
-            let root_path = get_root_path(&cargo_cmd)?;
-            let mut workspace = Workspace::from_path(cargo_cmd, root_path)?;
-            task.exec(args, &mut workspace, &tasks)
-        }
     }
 }
 
@@ -88,7 +83,7 @@ fn init_tasks() -> Tasks {
             name: "ci".into(),
             description: "run checks for CI".into(),
             flags: task_flags! {},
-            run: |_opts, workspace, tasks| {
+            run: |_opts, _fs, _git, _cargo, _workspace, tasks| {
                 println!(":::::::::::::::::::::::::::::::::");
                 println!(":::: Checking Project for CI ::::");
                 println!(":::::::::::::::::::::::::::::::::");
@@ -97,11 +92,11 @@ fn init_tasks() -> Tasks {
                 tasks
                     .get("lint")
                     .unwrap()
-                    .exec(vec![], workspace, tasks)?;
+                    .exec(vec![], tasks)?;
                 tasks
                     .get("coverage")
                     .unwrap()
-                    .exec(vec![], workspace, tasks)?;
+                    .exec(vec![], tasks)?;
 
                 println!(":::: Done!");
                 println!();
@@ -112,15 +107,14 @@ fn init_tasks() -> Tasks {
             name: "clean".into(),
             description: "delete temporary files".into(),
             flags: task_flags! {},
-            run: |_opts, workspace, _tasks| {
+            run: |_opts, fs, _git, cargo, workspace, _tasks| {
                 println!("::::::::::::::::::::::::::::");
                 println!(":::: Cleaning Workspace ::::");
                 println!("::::::::::::::::::::::::::::");
                 println!();
 
-                workspace.clean().unwrap_or(()); // ignore error
-                workspace.create_dirs()?;
-                cmd!(&workspace.cargo_cmd, "clean", "--release").run()?;
+                workspace.clean(&fs, &cargo)?;
+                workspace.create_dirs(&fs)?;
 
                 println!(":::: Done!");
                 println!();
@@ -138,7 +132,7 @@ fn init_tasks() -> Tasks {
             flags: task_flags! {
                 "open" => "open coverage report for viewing"
             },
-            run: |opts, workspace, tasks| {
+            run: |opts, _fs, _git, cargo, _workspace, tasks| {
                 println!("::::::::::::::::::::::::::::::");
                 println!(":::: Calculating Coverage ::::");
                 println!("::::::::::::::::::::::::::::::");
@@ -147,16 +141,8 @@ fn init_tasks() -> Tasks {
                 let coverage_root = PathBuf::from("tmp/coverage").display().to_string();
                 let report = format!("{}/html/index.html", &coverage_root);
 
-                tasks.get("clean").unwrap().exec(vec![], workspace, tasks)?;
-
-                cmd!(&workspace.cargo_cmd, "test")
-                    .env("CARGO_INCREMENTAL", "0")
-                    .env("RUSTFLAGS", "-Cinstrument-coverage")
-                    .env(
-                        "LLVM_PROFILE_FILE",
-                        format!("{}/cargo-test-%p-%m.profraw", &coverage_root),
-                    )
-                    .run()?;
+                tasks.get("clean").unwrap().exec(vec![], tasks)?;
+                cargo.coverage(&coverage_root).run()?;
 
                 println!(":::: Done!");
                 println!();
@@ -189,14 +175,13 @@ fn init_tasks() -> Tasks {
                 )
                 .run()?;
 
-
                 if opts.has("open"){
-                    cmd!("open", report).run()?;
-                } else {
-                    println!(":::: Done!");
-                    println!(":::: Report: {}", report);
-                    println!();
+                    cmd!("open", &report).run()?;
                 }
+
+                println!(":::: Done!");
+                println!(":::: Report: {}", report);
+                println!();
 
                 Ok(())
             },
@@ -204,8 +189,10 @@ fn init_tasks() -> Tasks {
         Task {
             name: "crate:add".into(),
             description: "add new crate to workspace".into(),
-            flags: task_flags! {},
-            run: |_opts, workspace, _tasks| {
+            flags: task_flags! {
+                "dry-run" => "run thru steps but do not create new crate"
+            },
+            run: |_opts, fs, _git, cargo, workspace, _tasks| {
                 println!(":::::::::::::::::::");
                 println!(":::: Add Crate ::::");
                 println!(":::::::::::::::::::");
@@ -235,8 +222,15 @@ fn init_tasks() -> Tasks {
 
                 let question = InquireSelect::new("Crate type?", vec!["--lib", "--bin"]);
                 let kind_flag = question.prompt()?;
+                let krate = Krate::new(
+                    kind_flag,
+                    "0.1.0",
+                    &name,
+                    description,
+                    workspace.krates_path().join(&name)
+                );
 
-                workspace.add_krate(kind_flag, "0.1.0", &name, &description)?;
+                workspace.add_krate(&fs, &cargo, krate)?;
 
                 println!(":::: Done!");
                 println!();
@@ -248,13 +242,13 @@ fn init_tasks() -> Tasks {
             name: "crate:list".into(),
             description: "list workspace crates".into(),
             flags: task_flags! {},
-            run: |_opts, workspace, _tasks| {
+            run: |_opts, fs, _git, _cargo, workspace, _tasks| {
                 println!("::::::::::::::::::::::::::");
                 println!(":::: Available Crates ::::");
                 println!("::::::::::::::::::::::::::");
                 println!();
 
-                let krates = workspace.krates()?;
+                let krates = workspace.krates(&fs)?;
 
                 for krate in krates.values() {
                     let kind = krate.kind.to_string().replace('-', "");
@@ -274,14 +268,13 @@ fn init_tasks() -> Tasks {
             flags: task_flags! {
                 "dry-run" => "run thru steps but do not publish"
             },
-            run: |opts, workspace, _tasks| {
+            run: |_opts, fs, git, cargo, workspace, _tasks| {
                 println!(":::::::::::::::::::::::::::");
                 println!(":::: Publishing Crates ::::");
                 println!(":::::::::::::::::::::::::::");
                 println!();
 
-                let git = Git::new(&opts);
-                let krates = workspace.krates()?;
+                let krates = workspace.krates(&fs)?;
                 let tag_text = git.get_tags(["--points-at", "HEAD"]).read()?;
                 let mut tags = vec![];
 
@@ -302,13 +295,8 @@ fn init_tasks() -> Tasks {
                     let (name, _ver) = tag.split_once('@').unwrap_or_else(|| panic!("Invalid Tag: `{}`!", tag));
                     let krate = krates.get(name).unwrap_or_else(|| panic!("Could Not Find Crate: `{}`!", name));
                     let message = format!("Publishing: {} at v{}", &krate.name, &krate.version);
-
-                    if opts.has("dry-run") {
-                        println!("{} [skip]", &message);
-                    } else {
-                        println!("{}", &message);
-                        cmd!(&workspace.cargo_cmd, "publish", "--package", &krate.name).run()?;
-                    }
+                    println!("{}", &message);
+                    cargo.publish_package(&krate.name).run()?;
                 }
 
                 println!();
@@ -323,14 +311,13 @@ fn init_tasks() -> Tasks {
             flags: task_flags! {
                 "dry-run" => "run thru steps but do not save changes"
             },
-            run: |opts, workspace, _tasks| {
+            run: |_opts, fs, git, _cargo, workspace, _tasks| {
                 println!("::::::::::::::::::::::::::");
                 println!(":::: Releasing Crates ::::");
                 println!("::::::::::::::::::::::::::");
                 println!();
 
-                let git = Git::new(&opts);
-                let mut krates = workspace.krates()?;
+                let mut krates = workspace.krates(&fs)?;
                 let question = InquireMultiSelect::new("Which crates should be published?", krates.keys().cloned().collect());
                 let to_publish = question
                     .with_validator(|selections: &[InquireListOption<&String>]| {
@@ -352,11 +339,7 @@ fn init_tasks() -> Tasks {
                     let question = InquireSelect::new(&message, options);
                     let choice = question.prompt()?;
                     krate.set_version(choice.get_version())?;
-                    if opts.has("dry-run") {
-                        println!("Skipping: Version bump for {}", krate.toml.path.display());
-                    } else {
-                        krate.toml.save()?;
-                    }
+                    krate.toml.save(&fs)?;
                     git.add(&krate.toml.path, [""]).run()?;
                 }
 
@@ -377,14 +360,14 @@ fn init_tasks() -> Tasks {
             name: "dist".into(),
             description: "create release artifacts".into(),
             flags: task_flags! {},
-            run: |_opts, workspace, _tasks| {
+            run: |_opts, _fs, _git, cargo, workspace, _tasks| {
                 println!(":::::::::::::::::::::::::::::::::::::::::::");
                 println!(":::: Building Project for Distribution ::::");
                 println!(":::::::::::::::::::::::::::::::::::::::::::");
                 println!();
 
                 let dist_dir = workspace.path().join("target/release");
-                cmd!(&workspace.cargo_cmd, "build", "--release").run()?;
+                cargo.build(["--release"]).run()?;
 
                 println!(":::: Done!");
                 println!(":::: Artifacts: {}", dist_dir.display());
@@ -397,19 +380,20 @@ fn init_tasks() -> Tasks {
             name: "doc".into(),
             description: "build project documentation".into(),
             flags: task_flags! {
+                "dry-run" => "run thru steps but do not generate docs",
                 "open" => "open rendered docs for viewing"
             },
-            run: |opts, workspace, _tasks| {
+            run: |opts, fs, _git, cargo, mut workspace, _tasks| {
                 println!(":::::::::::::::::::::::::::");
                 println!(":::: Building All Docs ::::");
                 println!(":::::::::::::::::::::::::::");
                 println!();
                 println!(":::: Updating Workspace README...");
 
-                let krates = workspace.krates()?;
+                let krates = workspace.krates(&fs)?;
                 let readme_path = workspace.readme.path.clone();
 
-                workspace.readme.update_crates_list(krates)?;
+                workspace.readme.update_crates_list(&fs, krates)?;
 
                 println!(":::: Done: {:?}", readme_path);
                 println!();
@@ -421,18 +405,18 @@ fn init_tasks() -> Tasks {
                 println!(":::: Testing Examples...");
                 println!();
 
-                cmd!(&workspace.cargo_cmd, "test", "--doc").run()?;
+                cargo.test(["--doc"]).run()?;
 
                 println!(":::: Rendering Docs...");
                 println!();
 
-                let mut args = vec!["doc", "--workspace", "--no-deps"];
+                let mut args = vec!["--workspace", "--no-deps"];
 
                 if opts.has("open") {
                     args.push("--open");
                 }
 
-                cmd(&workspace.cargo_cmd, args).run()?;
+                cargo.doc(args).run()?;
 
                 println!(":::: Done!");
                 println!();
@@ -444,21 +428,13 @@ fn init_tasks() -> Tasks {
             name: "lint".into(),
             description: "run the linter (clippy)".into(),
             flags: task_flags! {},
-            run: |_opts, workspace, _tasks| {
+            run: |_opts, _fs, _git, cargo, _workspace, _tasks| {
                 println!(":::::::::::::::::::::::::");
                 println!(":::: Linting Project ::::");
                 println!(":::::::::::::::::::::::::");
                 println!();
 
-                cmd!(
-                    &workspace.cargo_cmd,
-                    "clippy",
-                    "--all-targets",
-                    "--all-features",
-                    "--no-deps"
-                )
-                .env("RUSTFLAGS", "-Dwarnings")
-                .run()?;
+                cargo.lint().run()?;
 
                 println!(":::: Done!");
                 println!();
@@ -470,7 +446,7 @@ fn init_tasks() -> Tasks {
             name: "setup".into(),
             description: "bootstrap project for local development".into(),
             flags: task_flags! {},
-            run: |_opts, workspace, _tasks| {
+            run: |_opts, _fs, _git, cargo, _workspace, _tasks| {
                 println!("::::::::::::::::::::::::::::");
                 println!(":::: Setting up Project ::::");
                 println!("::::::::::::::::::::::::::::");
@@ -485,7 +461,7 @@ fn init_tasks() -> Tasks {
                 // TODO (busticated): is there a way to includes these in Cargo.toml or similar?
                 cmd!("rustup", "component", "add", "clippy").run()?;
                 cmd!("rustup", "component", "add", "llvm-tools-preview").run()?;
-                cmd!(&workspace.cargo_cmd, "install", "grcov").run()?;
+                cargo.install(["grcov"]).run()?;
 
                 println!(":::: Done!");
                 println!();
@@ -497,13 +473,13 @@ fn init_tasks() -> Tasks {
             name: "test".into(),
             description: "run all tests".into(),
             flags: task_flags! {},
-            run: |_opts, workspace, _tasks| {
+            run: |_opts, _fs, _git, cargo, _workspace, _tasks| {
                 println!(":::::::::::::::::::::::::");
                 println!(":::: Testing Project ::::");
                 println!(":::::::::::::::::::::::::");
                 println!();
 
-                cmd!(&workspace.cargo_cmd, "test").run()?;
+                cargo.test([""]).run()?;
 
                 println!(":::: Done!");
                 println!();
@@ -515,13 +491,12 @@ fn init_tasks() -> Tasks {
             name: "todo".into(),
             description: "list open to-dos based on inline source code comments".into(),
             flags: task_flags! {},
-            run: |opts, _workspace, _tasks| {
+            run: |_opts, _fs, git, _cargo, _workspace, _tasks| {
                 println!(":::::::::::::::");
                 println!(":::: TODOs ::::");
                 println!(":::::::::::::::");
                 println!();
 
-                let git = Git::new(&opts);
                 git.todos().run()?;
 
                 println!(":::: Done!");
@@ -533,21 +508,4 @@ fn init_tasks() -> Tasks {
     ]);
 
     tasks
-}
-
-fn get_cargo_cmd() -> String {
-    env::var("CARGO").unwrap_or_else(|_| "cargo".to_string())
-}
-
-fn get_root_path<T: AsRef<str>>(cargo_cmd: T) -> Result<PathBuf, DynError> {
-    let stdout = cmd!(
-        cargo_cmd.as_ref().to_owned(),
-        "locate-project",
-        "--workspace",
-        "--message-format",
-        "plain",
-    )
-    .read()?;
-
-    Ok(PathBuf::from(stdout.replace("Cargo.toml", "").trim()))
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,4 +1,5 @@
 mod cargo;
+mod exec;
 mod fs;
 mod git;
 mod krate;

--- a/xtask/src/options.rs
+++ b/xtask/src/options.rs
@@ -5,7 +5,7 @@ use std::error::Error;
 type DynError = Box<dyn Error>;
 type TaskFlags = BTreeMap<String, String>;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Options {
     pub args: Vec<String>,
     pub flags: TaskFlags,

--- a/xtask/src/readme.rs
+++ b/xtask/src/readme.rs
@@ -1,10 +1,10 @@
+use crate::fs::FS;
+use crate::krate::Krate;
 use regex::RegexBuilder;
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::fs;
 use std::path::PathBuf;
-use crate::fs::FS;
-use crate::krate::Krate;
 
 type DynError = Box<dyn Error>;
 

--- a/xtask/src/readme.rs
+++ b/xtask/src/readme.rs
@@ -1,9 +1,10 @@
-use crate::krate::Krate;
 use regex::RegexBuilder;
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::fs;
 use std::path::PathBuf;
+use crate::fs::FS;
+use crate::krate::Krate;
 
 type DynError = Box<dyn Error>;
 
@@ -29,6 +30,7 @@ impl Readme {
     }
 
     pub fn read(&self) -> Result<String, DynError> {
+        // TODO (busticated): pull into FS wrapper?
         Ok(fs::read_to_string(&self.path)?)
     }
 
@@ -37,17 +39,13 @@ impl Readme {
         Ok(self.clone())
     }
 
-    pub fn create<N: AsRef<str>, D: AsRef<str>>(
-        &mut self,
-        name: N,
-        description: D,
-    ) -> Result<(), DynError> {
-        self.text = self.render(name, description);
-        self.save()
+    pub fn create(&mut self, fs: &FS, krate: &Krate) -> Result<(), DynError> {
+        self.text = self.render(&krate.name, &krate.description);
+        self.save(fs)
     }
 
-    pub fn save(&self) -> Result<(), DynError> {
-        Ok(fs::write(&self.path, &self.text)?)
+    pub fn save(&self, fs: &FS) -> Result<(), DynError> {
+        Ok(fs.write(&self.path, &self.text)?)
     }
 
     pub fn render<N: AsRef<str>, D: AsRef<str>>(&self, name: N, description: D) -> String {
@@ -73,6 +71,7 @@ impl Readme {
 
     pub fn update_crates_list(
         &mut self,
+        fs: &FS,
         mut krates: BTreeMap<String, Krate>,
     ) -> Result<(), DynError> {
         self.load()?;
@@ -97,7 +96,7 @@ impl Readme {
         entries.push_str(marker_end);
         let updated = re.replace(&self.text, &entries);
         self.text = updated.as_ref().to_owned();
-        self.save()
+        self.save(fs)
     }
 }
 

--- a/xtask/src/semver.rs
+++ b/xtask/src/semver.rs
@@ -1,5 +1,5 @@
-use std::fmt::{Display, Formatter};
 use semver::{BuildMetadata, Prerelease, Version};
+use std::fmt::{Display, Formatter};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum VersionChoice {

--- a/xtask/src/tasks.rs
+++ b/xtask/src/tasks.rs
@@ -1,14 +1,20 @@
+use crate::cargo::Cargo;
 use crate::fs::FS;
 use crate::git::Git;
-use crate::cargo::Cargo;
 use crate::options::Options;
 use crate::workspace::Workspace;
 use std::collections::BTreeMap;
 use std::error::Error;
 
 type DynError = Box<dyn Error>;
-type TaskRunner =
-    fn(args: &Options, fs: FS, git: Git, cargo: Cargo, Workspace, &Tasks) -> Result<(), DynError>;
+type TaskRunner = fn(
+    opts: &Options,
+    fs: FS,
+    git: Git,
+    cargo: Cargo,
+    workspace: Workspace,
+    tasks: &Tasks,
+) -> Result<(), DynError>;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Task {

--- a/xtask/src/tasks.rs
+++ b/xtask/src/tasks.rs
@@ -1,16 +1,21 @@
+use crate::fs::FS;
+use crate::git::Git;
+use crate::cargo::Cargo;
 use crate::options::Options;
 use crate::workspace::Workspace;
 use std::collections::BTreeMap;
 use std::error::Error;
 
 type DynError = Box<dyn Error>;
+type TaskRunner =
+    fn(args: &Options, fs: FS, git: Git, cargo: Cargo, Workspace, &Tasks) -> Result<(), DynError>;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Task {
     pub name: String,
     pub description: String,
     pub flags: BTreeMap<String, String>,
-    pub run: fn(opts: Options, &mut Workspace, &Tasks) -> Result<(), DynError>,
+    pub run: TaskRunner,
 }
 
 impl Task {
@@ -19,7 +24,7 @@ impl Task {
         name: N,
         description: D,
         flags: BTreeMap<String, String>,
-        run: fn(args: Options, &mut Workspace, &Tasks) -> Result<(), DynError>,
+        run: TaskRunner,
     ) -> Self {
         Task {
             name: name.as_ref().to_owned(),
@@ -29,14 +34,13 @@ impl Task {
         }
     }
 
-    pub fn exec(
-        &self,
-        args: Vec<String>,
-        workspace: &mut Workspace,
-        tasks: &Tasks,
-    ) -> Result<(), DynError> {
+    pub fn exec(&self, args: Vec<String>, tasks: &Tasks) -> Result<(), DynError> {
         let opts = Options::new(args, self.flags.clone())?;
-        (self.run)(opts, workspace, tasks)?;
+        let cargo = Cargo::new(&opts);
+        let git = Git::new(&opts);
+        let fs = FS::new(&opts);
+        let workspace = Workspace::from_path(cargo.workspace_path()?)?;
+        (self.run)(&opts, fs, git, cargo, workspace, tasks)?;
         Ok(())
     }
 }
@@ -103,10 +107,12 @@ mod tests {
     use super::*;
     use crate::task_flags;
 
+    static FAKE_RUN: TaskRunner = |_, _, _, _, _, _| Ok(());
+
     #[test]
     fn it_initializes_a_task() {
         let flags = BTreeMap::from([("foo".into(), "does the foo".into())]);
-        let task = Task::new("test", "my test task", flags, |_, _, _| Ok(()));
+        let task = Task::new("test", "my test task", flags, FAKE_RUN);
         assert_eq!(task.name, "test");
         assert_eq!(task.description, "my test task");
     }
@@ -114,10 +120,9 @@ mod tests {
     #[test]
     fn it_executes_a_task() {
         let tasks = Tasks::new();
-        let mut workspace = Workspace::new("fake-cargo", std::path::PathBuf::from("fake-root"));
         let flags = BTreeMap::from([("foo".into(), "does the foo".into())]);
-        let task = Task::new("test", "my test task", flags, |_, _, _| Ok(()));
-        task.exec(vec![], &mut workspace, &tasks).unwrap();
+        let task = Task::new("test", "my test task", flags, FAKE_RUN);
+        task.exec(vec![], &tasks).unwrap();
     }
 
     #[test]
@@ -130,8 +135,8 @@ mod tests {
     fn it_add_a_task() {
         let mut tasks = Tasks::new();
         let flags = BTreeMap::from([("foo".into(), "does the foo".into())]);
-        let task1 = Task::new("one", "task 01", flags.clone(), |_, _, _| Ok(()));
-        let task2 = Task::new("two", "task 02", flags, |_, _, _| Ok(()));
+        let task1 = Task::new("one", "task 01", flags.clone(), FAKE_RUN);
+        let task2 = Task::new("two", "task 02", flags, FAKE_RUN);
 
         tasks.add(vec![task1, task2]);
 
@@ -144,8 +149,8 @@ mod tests {
     fn it_gets_a_task() {
         let mut tasks = Tasks::new();
         let flags = BTreeMap::from([("foo".into(), "does the foo".into())]);
-        let task1 = Task::new("one", "task 01", flags.clone(), |_, _, _| Ok(()));
-        let task2 = Task::new("two", "task 02", flags, |_, _, _| Ok(()));
+        let task1 = Task::new("one", "task 01", flags.clone(), FAKE_RUN);
+        let task2 = Task::new("two", "task 02", flags, FAKE_RUN);
 
         tasks.add(vec![task1, task2]);
         let task = tasks.get("one").unwrap();
@@ -166,7 +171,7 @@ mod tests {
                     "foo" => "does the foo",
                     "bar" => "enables bar",
                 },
-                run: |_, _, _| Ok(()),
+                run: FAKE_RUN,
             },
             Task {
                 name: "two".into(),
@@ -174,7 +179,7 @@ mod tests {
                 flags: task_flags! {
                     "baz" => "invokes a baz",
                 },
-                run: |_, _, _| Ok(()),
+                run: FAKE_RUN,
             },
         ]);
 

--- a/xtask/src/toml.rs
+++ b/xtask/src/toml.rs
@@ -1,10 +1,10 @@
+use crate::fs::FS;
+use crate::krate::Krate;
+use semver::Version;
 use std::error::Error;
 use std::fs;
 use std::path::{Path, PathBuf};
-use toml_edit::{Document, value as toml_value};
-use semver::Version;
-use crate::fs::FS;
-use crate::krate::Krate;
+use toml_edit::{value as toml_value, Document};
 
 type DynError = Box<dyn Error>;
 

--- a/xtask/src/workspace.rs
+++ b/xtask/src/workspace.rs
@@ -1,11 +1,11 @@
+use crate::fs::FS;
+use crate::cargo::Cargo;
 use crate::krate::{Krate, KratePaths};
 use crate::readme::Readme;
 use crate::toml::Toml;
-use duct::cmd;
 use std::collections::BTreeMap;
 use std::error::Error;
-use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 type DynError = Box<dyn Error>;
 
@@ -14,7 +14,6 @@ const CRATES_DIRNAME: &str = "crates";
 #[derive(Clone, Debug, Default)]
 pub struct Workspace {
     pub path: PathBuf,
-    pub cargo_cmd: String,
     pub readme: Readme,
     pub toml: Toml,
 }
@@ -27,38 +26,28 @@ impl KratePaths for Workspace {
 
 impl Workspace {
     #[allow(dead_code)]
-    pub fn new<C: AsRef<str>>(cargo_cmd: C, path: PathBuf) -> Self {
-        let cargo_cmd = cargo_cmd.as_ref().to_owned();
+    pub fn new<P: AsRef<Path>>(path: P) -> Self {
+        let path = path.as_ref().to_owned();
         let readme = Readme::new(path.clone());
         let toml = Toml::new(path.clone());
-        Workspace {
-            cargo_cmd,
-            path,
-            readme,
-            toml,
-        }
+        Workspace { path, readme, toml }
     }
 
-    pub fn from_path<C: AsRef<str>>(cargo_cmd: C, path: PathBuf) -> Result<Workspace, DynError> {
-        let cargo_cmd = cargo_cmd.as_ref().to_owned();
+    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Workspace, DynError> {
+        let path = path.as_ref().to_owned();
         let readme = Readme::from_path(path.clone())?;
         let toml = Toml::from_path(path.clone())?;
-        Ok(Workspace {
-            cargo_cmd,
-            path,
-            readme,
-            toml,
-        })
+        Ok(Workspace { path, readme, toml })
     }
 
     pub fn krates_path(&self) -> PathBuf {
         self.path().join(CRATES_DIRNAME)
     }
 
-    pub fn krates(&self) -> Result<BTreeMap<String, Krate>, DynError> {
+    pub fn krates(&self, fs: &FS) -> Result<BTreeMap<String, Krate>, DynError> {
         let mut krates = BTreeMap::new();
 
-        for entry in fs::read_dir(self.krates_path())? {
+        for entry in fs.read_dir(self.krates_path())? {
             let entry = entry?;
             let path = entry.path();
             if path.is_dir() {
@@ -70,49 +59,42 @@ impl Workspace {
         Ok(krates)
     }
 
-    pub fn add_krate<K: AsRef<str>, V: AsRef<str>, N: AsRef<str>, D: AsRef<str>>(
-        &self,
-        kind: K,
-        version: V,
-        name: N,
-        description: D,
-    ) -> Result<Krate, DynError> {
-        let path = self.krates_path().join(name.as_ref());
-        let mut krate = Krate::new(kind, version, name, description, path);
-
-        cmd!(
-            &self.cargo_cmd,
-            "new",
-            &krate.path,
-            "--name",
-            &krate.name,
-            krate.kind.to_string()
-        )
-        .run()?;
-
-        krate.readme.create(&krate.name, &krate.description)?;
-        krate.toml.create(&krate.name, &krate.description)?;
-
+    pub fn add_krate(&self, fs: &FS, cargo: &Cargo, mut krate: Krate) -> Result<Krate, DynError> {
+        let kind = krate.kind.to_string();
+        cargo
+            .create(&krate.path, ["--name", &krate.name, &kind])
+            .run()?;
+        krate.readme.create(fs, &krate.clone())?;
+        krate.toml.create(fs, &krate.clone())?;
         Ok(krate)
     }
 
-    pub fn clean(&self) -> Result<(), DynError> {
-        fs::remove_dir_all(self.tmp_path())?;
-        let krates = self.krates()?;
+    pub fn clean(&self, fs: &FS, cargo: &Cargo) -> Result<(), DynError> {
+        use std::io::ErrorKind;
+
+        match fs.remove_dir_all(self.tmp_path()) {
+            Err(e) if e.kind() == ErrorKind::NotFound => (),
+            Err(e) => return Err(Box::new(e)),
+            Ok(()) => (),
+        };
+
+        let krates = self.krates(fs)?;
 
         for krate in krates.values() {
-            krate.clean()?;
+            krate.clean(fs)?;
         }
+
+        cargo.clean(["--release"]).run()?;
 
         Ok(())
     }
 
-    pub fn create_dirs(&self) -> Result<(), DynError> {
-        fs::create_dir_all(self.coverage_path())?;
-        let krates = self.krates()?;
+    pub fn create_dirs(&self, fs: &FS) -> Result<(), DynError> {
+        fs.create_dir_all(self.coverage_path())?;
+        let krates = self.krates(fs)?;
 
         for krate in krates.values() {
-            krate.create_dirs()?;
+            krate.create_dirs(fs)?;
         }
 
         Ok(())
@@ -127,28 +109,32 @@ mod tests {
 
     #[test]
     fn it_initializes_a_workspace() {
-        let workspace = Workspace::new("fake-cargo", PathBuf::from("fake-root"));
-        assert!(!workspace.cargo_cmd.is_empty());
+        let fake_path = PathBuf::from("fake-path");
+        let workspace = Workspace::new(fake_path);
+        assert_eq!(workspace.path, PathBuf::from("fake-path"));
     }
 
     #[test]
     fn it_gets_path_to_workspace() {
-        let workspace = Workspace::new("fake-cargo", PathBuf::from("fake-root"));
-        assert!(!workspace.cargo_cmd.is_empty());
-        assert_eq!(workspace.path(), PathBuf::from("fake-root"));
+        let fake_path = PathBuf::from("fake-path");
+        let workspace = Workspace::new(fake_path);
+        assert_eq!(workspace.path(), PathBuf::from("fake-path"));
     }
 
     #[test]
     fn it_gets_path_to_workspace_tmp_dir() {
-        let path = PathBuf::from("fake-root");
-        let workspace = Workspace::new("fake-cargo", path.clone());
-        assert_eq!(workspace.tmp_path(), path.join("tmp"));
+        let fake_path = PathBuf::from("fake-path");
+        let workspace = Workspace::new(&fake_path);
+        assert_eq!(workspace.tmp_path(), fake_path.join("tmp"));
     }
 
     #[test]
     fn it_gets_path_to_workspace_coverage_dir() {
-        let path = PathBuf::from("fake-root");
-        let workspace = Workspace::new("fake-cargo", path.clone());
-        assert_eq!(workspace.coverage_path(), path.join("tmp").join("coverage"));
+        let fake_path = PathBuf::from("fake-path");
+        let workspace = Workspace::new(&fake_path);
+        assert_eq!(
+            workspace.coverage_path(),
+            fake_path.join("tmp").join("coverage")
+        );
     }
 }

--- a/xtask/src/workspace.rs
+++ b/xtask/src/workspace.rs
@@ -1,5 +1,5 @@
-use crate::fs::FS;
 use crate::cargo::Cargo;
+use crate::fs::FS;
 use crate::krate::{Krate, KratePaths};
 use crate::readme::Readme;
 use crate::toml::Toml;
@@ -85,7 +85,6 @@ impl Workspace {
         }
 
         cargo.clean(["--release"]).run()?;
-
         Ok(())
     }
 


### PR DESCRIPTION
## Description

Refactors `Task` runner to expose `fs`, `git`, and `cargo` helpers which themselves have access to task options such that they respect flags like `--dry-run`. Also fixes CI error related to tag events and tunes code formatting settings.


## How to Test

1. Clone and setup this branch locally ([docs](https://github.com/busticated/rusty#installation))
2. Review available tasks: `cargo xtask --help`
3. Simulate adding a new crate: `cargo xtask crate:add --dry-run`
4. Simulate releasing a crate: `cargo xtask crate:release --dry-run`

**Outcome**

Task help should be clear, commands should execute and output the skipped operations (e.g. `skipping: cargo new /path/to/my-crate --name my-crate --lib`.


## Related / Discussions

#4 


## Completeness

- [x] PR opened :tada:
- [ ] Testing instructions have been provided
- [ ] Development [How-To's](https://github.com/busticated/rusty#development) have been provided
- [ ] Docs have been updated (`cargo xtask doc`)
- [ ] Branch is rebased against _target_ (typically `main`)

