### PR TITLE
feature/json

### DIFF
--- a/crates/node-js-release-info/Cargo.toml
+++ b/crates/node-js-release-info/Cargo.toml
@@ -24,7 +24,12 @@ repository.workspace = true
 [dependencies]
 reqwest = { version = "0.11.*" }
 semver = "1.*"
+serde = { version = "1.*", features = ["derive"], optional = true }
 tokio = { version = "1.*", default-features = false, features = ["macros", "net", "time"] }
 
 [dev-dependencies]
 mockito = "1.*"
+serde_json = "1.*"
+
+[features]
+json = ["dep:serde"]

--- a/crates/node-js-release-info/README.md
+++ b/crates/node-js-release-info/README.md
@@ -34,4 +34,23 @@ async fn main() -> Result<(), NodeJSRelInfoError> {
 }
 ```
 
+## Features
+
+Full `json` serialization + deserialization is avaialable via the `json` feature.
+
+```shell
+cargo add node-js-release-info --features json
+```
+
+```rust
+use node_js_release_info::{NodeJSRelInfo, NodeJSRelInfoError};
+
+#[tokio::main]
+async fn main() {
+  let info = NodeJSRelInfo::new("20.6.1").macos().arm64().to_owned();
+  let json = serde_json::to_string(&info).unwrap();
+  let info_deserialized = serde_json::from_str(&json).unwrap();
+  assert_eq!(info, info_deserialized);
+}
+```
 

--- a/crates/node-js-release-info/src/arch.rs
+++ b/crates/node-js-release-info/src/arch.rs
@@ -1,14 +1,22 @@
 use crate::error::NodeJSRelInfoError;
+#[cfg(feature = "json")]
+use serde::{Deserialize, Serialize};
 use std::env::consts::ARCH;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "json", derive(Deserialize, Serialize))]
 pub enum NodeJSArch {
+    #[cfg_attr(feature = "json", serde(rename = "x64"))]
     X64,
+    #[cfg_attr(feature = "json", serde(rename = "x86"))]
     X86,
+    #[cfg_attr(feature = "json", serde(rename = "arm64"))]
     ARM64,
+    #[cfg_attr(feature = "json", serde(rename = "armv7l"))]
     ARMV7L,
+    #[cfg_attr(feature = "json", serde(rename = "ppc64le"))]
     PPC64LE,
 }
 
@@ -142,5 +150,12 @@ mod tests {
     )]
     fn it_fails_when_arch_is_unrecognized() {
         NodeJSArch::from_str("NOPE!").unwrap();
+    }
+
+    #[test]
+    fn it_serializes_and_deserializes() {
+        let arch_json = serde_json::to_string(&NodeJSArch::X64).unwrap();
+        let arch: NodeJSArch = serde_json::from_str(&arch_json).unwrap();
+        assert_eq!(arch, NodeJSArch::X64);
     }
 }

--- a/crates/node-js-release-info/src/ext.rs
+++ b/crates/node-js-release-info/src/ext.rs
@@ -1,12 +1,19 @@
 use crate::error::NodeJSRelInfoError;
+#[cfg(feature = "json")]
+use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "json", derive(Deserialize, Serialize))]
 pub enum NodeJSPkgExt {
+    #[cfg_attr(feature = "json", serde(rename = "tar.gz"))]
     Targz,
+    #[cfg_attr(feature = "json", serde(rename = "tar.xz"))]
     Tarxz,
+    #[cfg_attr(feature = "json", serde(rename = "zip"))]
     Zip,
+    #[cfg_attr(feature = "json", serde(rename = "msi"))]
     Msi,
 }
 
@@ -108,5 +115,12 @@ mod tests {
     )]
     fn it_fails_when_arch_is_unrecognized() {
         NodeJSPkgExt::from_str("NOPE!").unwrap();
+    }
+
+    #[test]
+    fn it_serializes_and_deserializes() {
+        let ext_json = serde_json::to_string(&NodeJSPkgExt::Tarxz).unwrap();
+        let ext: NodeJSPkgExt = serde_json::from_str(&ext_json).unwrap();
+        assert_eq!(ext, NodeJSPkgExt::Tarxz);
     }
 }

--- a/crates/node-js-release-info/src/lib.rs
+++ b/crates/node-js-release-info/src/lib.rs
@@ -322,6 +322,8 @@ mod tests {
     use mockito::{Server, Mock};
     use super::*;
 
+    fn is_thread_safe<T: Sized + Send + Sync + Unpin>() {}
+
     #[test]
     fn it_initializes(){
         let info = NodeJSRelInfo::new("1.0.0");
@@ -332,6 +334,7 @@ mod tests {
         assert_eq!(info.filename, "".to_string());
         assert_eq!(info.sha256, "".to_string());
         assert_eq!(info.url, "".to_string());
+        is_thread_safe::<NodeJSRelInfo>();
     }
 
     #[test]

--- a/crates/node-js-release-info/src/lib.rs
+++ b/crates/node-js-release-info/src/lib.rs
@@ -248,29 +248,6 @@ impl NodeJSRelInfo {
         self.clone()
     }
 
-    /// Creates JSON String from instance
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use node_js_release_info::{NodeJSRelInfo, NodeJSRelInfoError};
-    /// let info = NodeJSRelInfo::new("20.6.1");
-    /// assert_eq!(info.to_json_string(), "{\"version\":\"20.6.1\",\"os\":\"linux\",\"arch\":\"x64\",\"filename\":\"node-v20.6.1-linux-x64.tar.gz\",\"sha256\":\"\",\"url\":\"\"}");
-    /// ```
-    // TODO (busticated): should probably just use serde
-    pub fn to_json_string(&self) -> String {
-        let entries = vec![
-            format!("\"version\":\"{}\"", self.version),
-            format!("\"os\":\"{}\"", self.os),
-            format!("\"arch\":\"{}\"", self.arch),
-            format!("\"filename\":\"{}\"", self.filename()),
-            format!("\"sha256\":\"{}\"", self.sha256),
-            format!("\"url\":\"{}\"", self.url),
-        ];
-
-        format!("{{{}}}", entries.join(","))
-    }
-
     /// Fetches Node.js metadata from the [releases download server](https://nodejs.org/download/release/)
     ///
     /// # Examples
@@ -465,37 +442,6 @@ mod tests {
         info1.windows();
 
         assert_ne!(info1, info2);
-    }
-
-    #[test]
-    fn it_gets_json_string() {
-        let mut info = NodeJSRelInfo::new("1.0.0").macos().x64().zip().to_owned();
-        info.sha256 = "fake-sha256".into();
-        info.url = "https://example.com/fake-url".into();
-        let json = info.to_json_string();
-        let result: Vec<&str> = json.split(',').collect();
-
-        assert_eq!(result, vec![
-            "{\"version\":\"1.0.0\"",
-            "\"os\":\"darwin\"",
-            "\"arch\":\"x64\"",
-            "\"filename\":\"node-v1.0.0-darwin-x64.zip\"",
-            "\"sha256\":\"fake-sha256\"",
-            "\"url\":\"https://example.com/fake-url\"}"
-        ]);
-
-        info.windows().arm64().msi();
-        let json = info.to_json_string();
-        let result: Vec<&str> = json.split(',').collect();
-
-        assert_eq!(result, vec![
-            "{\"version\":\"1.0.0\"",
-            "\"os\":\"win\"",
-            "\"arch\":\"arm64\"",
-            "\"filename\":\"node-v1.0.0-arm64.msi\"",
-            "\"sha256\":\"fake-sha256\"",
-            "\"url\":\"https://example.com/fake-url\"}"
-        ]);
     }
 
     #[test]

--- a/crates/node-js-release-info/src/os.rs
+++ b/crates/node-js-release-info/src/os.rs
@@ -1,12 +1,18 @@
 use crate::error::NodeJSRelInfoError;
+#[cfg(feature = "json")]
+use serde::{Deserialize, Serialize};
 use std::env::consts::OS;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "json", derive(Deserialize, Serialize))]
 pub enum NodeJSOS {
+    #[cfg_attr(feature = "json", serde(rename = "linux"))]
     Linux,
+    #[cfg_attr(feature = "json", serde(rename = "darwin"))]
     Darwin,
+    #[cfg_attr(feature = "json", serde(rename = "win"))]
     Windows,
 }
 
@@ -116,5 +122,12 @@ mod tests {
     )]
     fn it_fails_when_os_cannot_be_determined_from_str() {
         NodeJSOS::from_str("NOPE!").unwrap();
+    }
+
+    #[test]
+    fn it_serializes_and_deserializes() {
+        let os_json = serde_json::to_string(&NodeJSOS::Darwin).unwrap();
+        let os: NodeJSOS = serde_json::from_str(&os_json).unwrap();
+        assert_eq!(os, NodeJSOS::Darwin);
     }
 }

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -151,7 +151,7 @@ impl<'a> Cargo<'a> {
     {
         let mut profile_ptn: OsString = path.into();
         profile_ptn.push("/cargo-test-%p-%m.profraw");
-        let args = self.build_args([OsString::from("test")], [""]);
+        let args = self.build_args([OsString::from("test")], ["--all-features"]);
         let envs = HashMap::from([
             ("CARGO_INCREMENTAL".into(), "0".into()),
             ("RUSTFLAGS".into(), "-Cinstrument-coverage".into()),
@@ -286,7 +286,7 @@ mod tests {
             ),
         ]);
 
-        assert_eq!(args, ["test"]);
+        assert_eq!(args, ["test", "--all-features"]);
         assert_eq!(envs, Some(expected_envs));
     }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -402,12 +402,12 @@ fn init_tasks() -> Tasks {
                 println!(":::: Testing Examples...");
                 println!();
 
-                cargo.test(["--doc"]).run()?;
+                cargo.test(["--doc", "--all-features"]).run()?;
 
                 println!(":::: Rendering Docs...");
                 println!();
 
-                let mut args = vec!["--workspace", "--no-deps"];
+                let mut args = vec!["--workspace", "--no-deps", "--all-features"];
 
                 if opts.has("open") {
                     args.push("--open");
@@ -473,7 +473,7 @@ fn init_tasks() -> Tasks {
                 println!(":::::::::::::::::::::::::");
                 println!();
 
-                cargo.test([""]).run()?;
+                cargo.test(["--all-features"]).run()?;
 
                 println!(":::: Done!");
                 println!();


### PR DESCRIPTION
## Description

Adds `json` feature to the `node-js-release-info` crate to facilitate serializing + deserializing from / to `json` via [serde](https://github.com/serde-rs/serde)


## How to Test

1. Clone and setup this branch locally ([docs](https://github.com/busticated/rusty#installation))
2. Review docs: `cargo xtask doc --open`
3. Run tests: `cargo xtask test`
4. Try out the examples

**Outcome**

Tests should pass, docs and examples should be clear and helpful, and you should be able to successfully replicate and run the example.


## Related / Discussions

#1 


## Completeness

- [x] PR opened :tada:
- [x] Testing instructions have been provided
- [x] Development [How-To's](https://github.com/busticated/rusty#development) have been provided
- [x] Docs have been updated (`cargo xtask doc`)
- [x] Branch is rebased against _target_ (typically `main`)

