### PR TITLE
feature/changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ A `cargo` workspace ([docs](https://doc.rust-lang.org/book/ch14-03-cargo-workspa
 
 ## Development
 
-This repository contains a series of `rust` crates managed together as a `cargo` workspace ([docs](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html)) with [XTask](https://github.com/matklad/cargo-xtask). All essential commands are available via `cargo xtask <script name>` - e.g. `cargo xtask todo`. To view the available commands, run: `cargo xtask help`
+This repository contains a series of `rust` crates managed together as a `cargo` workspace ([docs](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html)) with [XTask](https://github.com/matklad/cargo-xtask). All essential commands are available via `cargo xtask <script name>` - e.g. `cargo xtask todo`. To view available commands, run: `cargo xtask help`
 
 
 <details id="develop-add-crate">
 <summary><b>How to add a new crate</b></summary>
 <p>
 
-To add a _new_ crate to the workspace, run `cargo xtask crate:add` and follow the prompts. Upon completion, your new crate will be available within `./crates/<your crate>`
+To add a _new_ crate to the workspace, run `cargo xtask crate:add` and follow the prompts (add the `--dry-run` flag to test). Upon completion, your new crate will be available within `./crates/<your crate>`
 
 </p>
 </details>
@@ -47,34 +47,52 @@ To add a _new_ crate to the workspace, run `cargo xtask crate:add` and follow th
 To run _all_ tests for _all_ crates:
 
 ```
-cargo test
+cargo xtask test
 ```
 
 To run _unit_ tests for _all_ crates:
 
 ```
-cargo test --lib --workspace
+cargo test --lib --all-features --workspace
 ```
 
 To run _unit_ tests for _just your_ crate:
 
 ```
-cargo test --lib --package <your crate's name>
+cargo test --lib --all-features --package <your crate's name>
 ```
 
 To run _integration_ tests for _all_ crates:
 
 ```
-cargo test --test integration --workspace
+cargo test --test integration --all-features --workspace
 ```
 
 To run _integration_ tests for _just your_ crate:
 
 ```
-cargo test --test integration --package <your crate's name>
+cargo test --test integration --all-features --package <your crate's name>
 ```
 
-Run `cargo xtask help` to see any other test-related commands that are available.
+To run tests for _docs_ and _examples_ in _all_ crates:
+
+```
+cargo test --doc --all-features --workspace
+```
+
+To run tests for _docs_ and _examples_ in _just your_ crate:
+
+```
+cargo test --doc --all-features --package <your crate's name>
+```
+
+To run a specific test:
+
+```
+cargo test --all-features <test name - e.g. "tests::it_fetches_node_js_release_info"> -- --exact
+```
+
+To output any `println!()` calls within tests, add the `--nocapture` flag after the `--` option delimiter. Run `cargo xtask help` to see any other test-related commands that are available.
 
 </p>
 </details>
@@ -86,7 +104,7 @@ Run `cargo xtask help` to see any other test-related commands that are available
 To see code coverage stats for _all_ crates:
 
 ```
-cargo xtask coverage
+cargo xtask coverage --open
 ```
 
 Run `cargo xtask help` to see any other coverage-related commands that are available.
@@ -118,7 +136,7 @@ Run `cargo xtask help` to see any other docs-related commands that are available
 To publish a crate to the [crates.io](https://crates.io) registry, follow these steps:
 
 1. Checkout the `main` branch: `git checkout main`
-2. Run `cargo xtask crate:release` and follow the prompts
+2. Run `cargo xtask crate:release` and follow the prompts (add the `--dry-run` flag to test)
 3. Verify all checks pass: `cargo xtask ci`
 4. Push to remote: `git push origin main --follow-tags`
 
@@ -149,6 +167,8 @@ e.g.
 // TODO (busticated): this is my example todo comment
 ```
 
+Any `todo!()` macros in the source code will also be reported.
+
 </p>
 </details>
 
@@ -162,5 +182,6 @@ e.g.
 * [Duct](https://github.com/oconnor663/duct.rs)
 * [TOML](https://github.com/toml-rs/toml)
 * [Inquire](https://github.com/mikaelmello/inquire)
+* [Reqwest](https://github.com/seanmonstar/reqwest)
 * [Mockito](https://github.com/lipanski/mockito)
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,29 @@ Run `cargo xtask help` to see any other docs-related commands that are available
 </p>
 </details>
 
+<details id="develop-changelog">
+<summary><b>How to format commits for changelogs</b></summary>
+<p>
+
+In order to support automated crate changelog updates, you will need to:
+
+* Commit crate changes separately - e.g. run: `git add -p crates/<name>/*` to stage files, then run `git add -p crates/<other-name>/*` and commit
+* Format your commit message like: `[<crate name>] <message>` e.g. `[node-js-release-info] update docs`
+* Commit changes to the workspace itself (including the `xtask` crate) separately without prefixing your commit message
+
+Each crate has its own changelog ([example](crates/node-js-release-info/CHANGELOG.md)). Upon releasing, each changelog will be updated with the changes made to that crate since its last release.
+
+To view unpublished changelog entries for all crates, run:
+
+```
+cargo xtask changelog
+```
+
+Run `cargo xtask help` to see any other changelog-related commands that are available.
+
+</p>
+</details>
+
 <details id="develop-publish-crate">
 <summary><b>How to publish crates</b></summary>
 <p>

--- a/crates/detect-newline-style/CHANGELOG.md
+++ b/crates/detect-newline-style/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `detect-newline-style` Changelog
-
+<!-- next-version-start -->
+<!-- next-version-end -->
 ## v0.1.1
 
 * add tests to cover no-op cases

--- a/crates/node-js-release-info/CHANGELOG.md
+++ b/crates/node-js-release-info/CHANGELOG.md
@@ -1,6 +1,6 @@
 # `node-js-release-info` Changelog
-
-
+<!-- next-version-start -->
+<!-- next-version-end -->
 ## v1.1.0
 
 * add docs and examples for .fetch_all() method

--- a/crates/node-js-release-info/src/error.rs
+++ b/crates/node-js-release-info/src/error.rs
@@ -45,9 +45,7 @@ impl Display for NodeJSRelInfoError {
             NodeJSRelInfoError::UnrecognizedConfiguration(input) => {
                 format!("Unrecognized Configuration! Received: '{}'", input)
             }
-            NodeJSRelInfoError::HttpError(e) => {
-                return write!(f, "{}", e)
-            }
+            NodeJSRelInfoError::HttpError(e) => return write!(f, "{}", e),
         };
 
         write!(f, "Error: {}", message)

--- a/crates/node-js-release-info/src/lib.rs
+++ b/crates/node-js-release-info/src/lib.rs
@@ -1,20 +1,20 @@
 #![doc = include_str!("../README.md")]
 
-mod os;
 mod arch;
 mod error;
 mod ext;
+mod os;
 mod specs;
 mod url;
 
-use std::string::ToString;
-#[cfg(feature = "json")]
-use serde::{Serialize, Deserialize};
-pub use crate::os::NodeJSOS;
 pub use crate::arch::NodeJSArch;
 pub use crate::error::NodeJSRelInfoError;
 pub use crate::ext::NodeJSPkgExt;
+pub use crate::os::NodeJSOS;
 use crate::url::NodeJSURLFormatter;
+#[cfg(feature = "json")]
+use serde::{Deserialize, Serialize};
+use std::string::ToString;
 
 #[derive(Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "json", derive(Deserialize, Serialize))]
@@ -322,9 +322,7 @@ impl NodeJSRelInfo {
         let version = specs::validate_version(self.version.as_str())?;
         let specs = specs::fetch(&version, &self.url_fmt).await?;
         let filename = self.filename();
-        let info = specs.lines().find(|&line| {
-            line.contains(filename.as_str())
-        });
+        let info = specs.lines().find(|&line| line.contains(filename.as_str()));
 
         let mut specs = match info {
             None => return Err(NodeJSRelInfoError::UnrecognizedConfiguration(filename))?,
@@ -403,13 +401,13 @@ impl NodeJSRelInfo {
 
 #[cfg(test)]
 mod tests {
-    use mockito::Server;
     use super::*;
+    use mockito::Server;
 
     fn is_thread_safe<T: Sized + Send + Sync + Unpin>() {}
 
     #[test]
-    fn it_initializes(){
+    fn it_initializes() {
         let info = NodeJSRelInfo::new("1.0.0");
         assert_eq!(info.os, NodeJSOS::Linux);
         assert_eq!(info.arch, NodeJSArch::X64);
@@ -563,7 +561,8 @@ mod tests {
         let version = "20.6.1".to_string();
         let filename = "node-v20.6.1-darwin-arm64.tar.gz".to_string();
         let sha256 = "d8ba8018d45b294429b1a7646ccbeaeb2af3cdf45b5c91dabbd93e2a2035cb46".to_string();
-        let url = "https://nodejs.org/download/release/v20.6.1/node-v20.6.1-darwin-arm64.tar.gz".to_string();
+        let url = "https://nodejs.org/download/release/v20.6.1/node-v20.6.1-darwin-arm64.tar.gz"
+            .to_string();
         let info_orig = NodeJSRelInfo {
             os: NodeJSOS::Darwin,
             arch: NodeJSArch::ARM64,
@@ -580,20 +579,34 @@ mod tests {
         assert_eq!(info.arch, NodeJSArch::ARM64);
         assert_eq!(info.ext, NodeJSPkgExt::Targz);
         assert_eq!(info.version, "20.6.1".to_string());
-        assert_eq!(info.filename, "node-v20.6.1-darwin-arm64.tar.gz".to_string());
-        assert_eq!(info.sha256, "d8ba8018d45b294429b1a7646ccbeaeb2af3cdf45b5c91dabbd93e2a2035cb46".to_string());
-        assert_eq!(info.url, "https://nodejs.org/download/release/v20.6.1/node-v20.6.1-darwin-arm64.tar.gz".to_string());
+        assert_eq!(
+            info.filename,
+            "node-v20.6.1-darwin-arm64.tar.gz".to_string()
+        );
+        assert_eq!(
+            info.sha256,
+            "d8ba8018d45b294429b1a7646ccbeaeb2af3cdf45b5c91dabbd93e2a2035cb46".to_string()
+        );
+        assert_eq!(
+            info.url,
+            "https://nodejs.org/download/release/v20.6.1/node-v20.6.1-darwin-arm64.tar.gz"
+                .to_string()
+        );
     }
 
     #[tokio::test]
-    #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: InvalidVersion(\"NOPE!\")")]
+    #[should_panic(
+        expected = "called `Result::unwrap()` on an `Err` value: InvalidVersion(\"NOPE!\")"
+    )]
     async fn it_fails_to_fetch_info_when_version_is_invalid() {
         let mut info = NodeJSRelInfo::new("NOPE!");
         info.fetch().await.unwrap();
     }
 
     #[tokio::test]
-    #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: UnrecognizedVersion(\"1.0.0\")")]
+    #[should_panic(
+        expected = "called `Result::unwrap()` on an `Err` value: UnrecognizedVersion(\"1.0.0\")"
+    )]
     async fn it_fails_to_fetch_info_when_version_is_unrecognized() {
         let mut info = NodeJSRelInfo::new("1.0.0");
         let mut server = Server::new_async().await;
@@ -608,7 +621,9 @@ mod tests {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: UnrecognizedConfiguration(\"node-v20.6.1-linux-x64.zip\")")]
+    #[should_panic(
+        expected = "called `Result::unwrap()` on an `Err` value: UnrecognizedConfiguration(\"node-v20.6.1-linux-x64.zip\")"
+    )]
     async fn it_fails_to_fetch_info_when_configuration_is_unrecognized() {
         let mut server = Server::new_async().await;
         let mut info = NodeJSRelInfo::new("20.6.1").linux().zip().to_owned();
@@ -634,8 +649,18 @@ mod tests {
         mock.assert_async().await;
 
         assert_eq!(info.filename, "node-v20.6.1-linux-x64.tar.gz");
-        assert_eq!(info.url, format!("{}{}", server.url(), "/download/release/v20.6.1/node-v20.6.1-linux-x64.tar.gz"));
-        assert_eq!(info.sha256, "26dd13a6f7253f0ab9bcab561353985a297d927840771d905566735b792868da");
+        assert_eq!(
+            info.url,
+            format!(
+                "{}{}",
+                server.url(),
+                "/download/release/v20.6.1/node-v20.6.1-linux-x64.tar.gz"
+            )
+        );
+        assert_eq!(
+            info.sha256,
+            "26dd13a6f7253f0ab9bcab561353985a297d927840771d905566735b792868da"
+        );
     }
 
     #[tokio::test]
@@ -651,8 +676,18 @@ mod tests {
         mock.assert_async().await;
 
         assert_eq!(info.filename, "node-v20.6.1-arm64.msi");
-        assert_eq!(info.url, format!("{}{}", server.url(), "/download/release/v20.6.1/node-v20.6.1-arm64.msi"));
-        assert_eq!(info.sha256, "9471bd6dc491e09c31b0f831f5953284b8a6842ed4ccb98f5c62d13e6086c471");
+        assert_eq!(
+            info.url,
+            format!(
+                "{}{}",
+                server.url(),
+                "/download/release/v20.6.1/node-v20.6.1-arm64.msi"
+            )
+        );
+        assert_eq!(
+            info.sha256,
+            "9471bd6dc491e09c31b0f831f5953284b8a6842ed4ccb98f5c62d13e6086c471"
+        );
     }
 
     #[tokio::test]
@@ -673,12 +708,20 @@ mod tests {
         assert_eq!(all[2].arch, NodeJSArch::ARM64);
         assert_eq!(all[2].ext, NodeJSPkgExt::Targz);
         assert_eq!(all[2].filename, "node-v20.6.1-darwin-arm64.tar.gz");
-        assert_eq!(all[2].sha256, "d8ba8018d45b294429b1a7646ccbeaeb2af3cdf45b5c91dabbd93e2a2035cb46");
-        assert_eq!(all[2].url, "https://nodejs.org/download/release/v20.6.1/node-v20.6.1-darwin-arm64.tar.gz");
+        assert_eq!(
+            all[2].sha256,
+            "d8ba8018d45b294429b1a7646ccbeaeb2af3cdf45b5c91dabbd93e2a2035cb46"
+        );
+        assert_eq!(
+            all[2].url,
+            "https://nodejs.org/download/release/v20.6.1/node-v20.6.1-darwin-arm64.tar.gz"
+        );
     }
 
     #[tokio::test]
-    #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: UnrecognizedVersion(\"1.0.0\")")]
+    #[should_panic(
+        expected = "called `Result::unwrap()` on an `Err` value: UnrecognizedVersion(\"1.0.0\")"
+    )]
     async fn it_fails_to_fetch_all_supported_node_js_configurations_when_version_is_unrecognized() {
         let mut info = NodeJSRelInfo::new("1.0.0");
         let mut server = Server::new_async().await;

--- a/crates/node-js-release-info/tests/integration.rs
+++ b/crates/node-js-release-info/tests/integration.rs
@@ -18,6 +18,12 @@ fn it_provides_expected_resources() {
 async fn it_works() {
     let mut info = NodeJSRelInfo::new(VERSION);
     let result = info.macos().x64().tar_gz().fetch().await.unwrap();
-    assert_eq!(result.url, "https://nodejs.org/download/release/v20.7.0/node-v20.7.0-darwin-x64.tar.gz");
-    assert_eq!(result.sha256, "ceeba829f44e7573949f2ce2ad5def27f1d6daa55f2860bea82964851fae01bc");
+    assert_eq!(
+        result.url,
+        "https://nodejs.org/download/release/v20.7.0/node-v20.7.0-darwin-x64.tar.gz"
+    );
+    assert_eq!(
+        result.sha256,
+        "ceeba829f44e7573949f2ce2ad5def27f1d6daa55f2860bea82964851fae01bc"
+    );
 }

--- a/crates/node-js-release-info/tests/integration.rs
+++ b/crates/node-js-release-info/tests/integration.rs
@@ -15,7 +15,7 @@ fn it_provides_expected_resources() {
 }
 
 #[tokio::test]
-async fn it_works() {
+async fn it_fetches_node_js_release_info_for_a_given_configuration() {
     let mut info = NodeJSRelInfo::new(VERSION);
     let result = info.macos().x64().tar_gz().fetch().await.unwrap();
     assert_eq!(
@@ -24,6 +24,21 @@ async fn it_works() {
     );
     assert_eq!(
         result.sha256,
+        "ceeba829f44e7573949f2ce2ad5def27f1d6daa55f2860bea82964851fae01bc"
+    );
+}
+
+#[tokio::test]
+async fn it_fetches_node_js_release_info_for_all_supported_configurations() {
+    let info = NodeJSRelInfo::new(VERSION);
+    let result = info.fetch_all().await.unwrap();
+    assert_eq!(result.len(), 24);
+    assert_eq!(
+        result[4].url,
+        "https://nodejs.org/download/release/v20.7.0/node-v20.7.0-darwin-x64.tar.gz"
+    );
+    assert_eq!(
+        result[4].sha256,
         "ceeba829f44e7573949f2ce2ad5def27f1d6daa55f2860bea82964851fae01bc"
     );
 }

--- a/xtask/src/changelog.rs
+++ b/xtask/src/changelog.rs
@@ -1,0 +1,128 @@
+use crate::fs::FS;
+use crate::krate::Krate;
+use regex::RegexBuilder;
+use semver::Version;
+use std::error::Error;
+use std::fs;
+use std::path::PathBuf;
+
+type DynError = Box<dyn Error>;
+
+const CHANGELOG_MD: &str = "CHANGELOG.md";
+const MARKER_START: &str = "<!-- next-version-start -->";
+const MARKER_END: &str = "<!-- next-version-end -->";
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Changelog {
+    pub path: PathBuf,
+    text: String,
+}
+
+impl Changelog {
+    pub fn new(crate_root: PathBuf) -> Self {
+        Changelog {
+            text: String::new(),
+            path: crate_root.join(CHANGELOG_MD),
+        }
+    }
+
+    pub fn from_path(crate_root: PathBuf) -> Result<Self, DynError> {
+        let mut changelog = Changelog::new(crate_root);
+        changelog.load()
+    }
+
+    pub fn read(&self) -> Result<String, DynError> {
+        // TODO (busticated): pull into FS wrapper?
+        Ok(fs::read_to_string(&self.path)?)
+    }
+
+    pub fn load(&mut self) -> Result<Self, DynError> {
+        self.text = self.read()?;
+        Ok(self.clone())
+    }
+
+    pub fn create(&mut self, fs: &FS, krate: &Krate) -> Result<(), DynError> {
+        self.text = self.render(&krate.name, &krate.version);
+        self.save(fs)
+    }
+
+    pub fn save(&self, fs: &FS) -> Result<(), DynError> {
+        Ok(fs.write(&self.path, &self.text)?)
+    }
+
+    pub fn render<N: AsRef<str>>(&self, name: N, version: &Version) -> String {
+        let name = name.as_ref();
+        let lines = vec![
+            format!("# `{}` Changelog", name),
+            MARKER_START.to_string(),
+            MARKER_END.to_string(),
+            format!("## v{}", version),
+            "".to_string(),
+            "* Initial release 🎊🎉".to_string(),
+            "".to_string(),
+        ];
+        lines.join("\n")
+    }
+
+    pub fn update(&mut self, fs: &FS, krate: &Krate, commits: Vec<String>) -> Result<(), DynError> {
+        if commits.is_empty() {
+            return Ok(());
+        }
+        self.load()?;
+        let mut log = format!("{}\n{}\n", MARKER_START, MARKER_END);
+        log.push_str(format!("## v{}\n\n", &krate.version).as_str());
+        for msg in commits.iter() {
+            if msg.is_empty() {
+                continue;
+            }
+            let prefix = format!("[{}]", &krate.name);
+            let msg = msg.trim().replace(&prefix, "");
+            log.push_str(format!("* {}\n", &msg).as_str());
+        }
+        log.push('\n');
+        let ptn = format!(r"{}[\s\S]*?{}", MARKER_START, MARKER_END);
+        let re = RegexBuilder::new(ptn.as_str())
+            .case_insensitive(true)
+            .multi_line(true)
+            .build()?;
+        let updated = re.replace(&self.text, &log);
+        self.text = updated.as_ref().to_owned();
+        self.save(fs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_initializes() {
+        let fake_crate_root = PathBuf::from("fake-crate-root");
+        let changelog = Changelog::new(fake_crate_root);
+        assert_eq!(changelog.text, "");
+        assert_eq!(
+            changelog.path,
+            PathBuf::from("fake-crate-root/CHANGELOG.md")
+        );
+    }
+
+    #[test]
+    fn it_renders() {
+        let fake_crate_root = PathBuf::from("fake-crate-root");
+        let version = Version::new(0, 1, 0);
+        let changelog = Changelog::new(fake_crate_root);
+        assert_eq!(
+            changelog.render("my-crate", &version),
+            [
+                "# `my-crate` Changelog",
+                "<!-- next-version-start -->",
+                "<!-- next-version-end -->",
+                "## v0.1.0",
+                "",
+                "* Initial release 🎊🎉",
+                "",
+            ]
+            .join("\n")
+        );
+    }
+}

--- a/xtask/src/krate.rs
+++ b/xtask/src/krate.rs
@@ -1,3 +1,4 @@
+use crate::changelog::Changelog;
 use crate::fs::FS;
 use crate::readme::Readme;
 use crate::toml::Toml;
@@ -21,6 +22,7 @@ pub struct Krate {
     pub name: String,
     pub description: String,
     pub path: PathBuf,
+    pub changelog: Changelog,
     pub readme: Readme,
     pub toml: Toml,
 }
@@ -38,6 +40,7 @@ impl Default for Krate {
         let name = String::default();
         let description = String::default();
         let path = PathBuf::default();
+        let changelog = Changelog::default();
         let readme = Readme::default();
         let toml = Toml::default();
         Krate {
@@ -46,6 +49,7 @@ impl Default for Krate {
             name,
             description,
             path,
+            changelog,
             readme,
             toml,
         }
@@ -64,6 +68,7 @@ impl Krate {
         let version = Version::parse(version.as_ref()).unwrap_or(Version::new(0, 1, 0));
         let name = name.as_ref().to_owned();
         let description = description.as_ref().to_owned();
+        let changelog = Changelog::new(path.clone());
         let readme = Readme::new(path.clone());
         let toml = Toml::new(path.clone());
         Krate {
@@ -72,6 +77,7 @@ impl Krate {
             name,
             description,
             path,
+            changelog,
             readme,
             toml,
         }
@@ -80,6 +86,7 @@ impl Krate {
     pub fn from_path(path: PathBuf) -> Result<Krate, DynError> {
         let toml = Toml::from_path(path.clone())?;
         let readme = Readme::from_path(path.clone())?;
+        let changelog = Changelog::from_path(path.clone())?;
         let kind = KrateKind::from_path(path.clone())?;
         let name = toml.get_name()?;
         let description = toml.get_description()?;
@@ -90,6 +97,7 @@ impl Krate {
             name,
             description,
             path,
+            changelog,
             readme,
             toml,
         };

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -185,7 +185,7 @@ fn init_tasks() -> Tasks {
                 println!("::::::::::::::::::::::::::::::");
                 println!();
 
-                let coverage_root = PathBuf::from("tmp/coverage").display().to_string();
+                let coverage_root = String::from("tmp/coverage");
                 let report = format!("{}/html/index.html", &coverage_root);
 
                 tasks.get("clean").unwrap().exec(vec![], tasks)?;
@@ -433,20 +433,6 @@ fn init_tasks() -> Tasks {
                 println!(":::: Building All Docs ::::");
                 println!(":::::::::::::::::::::::::::");
                 println!();
-                println!(":::: Updating Workspace README...");
-
-                let krates = workspace.krates(&fs)?;
-                let readme_path = workspace.readme.path.clone();
-
-                workspace.readme.update_crates_list(&fs, krates)?;
-
-                println!(":::: Done: {:?}", readme_path);
-                println!();
-
-                if opts.has("open") {
-                    cmd!("open", readme_path.to_str().unwrap()).run()?;
-                }
-
                 println!(":::: Testing Examples...");
                 println!();
 
@@ -462,6 +448,20 @@ fn init_tasks() -> Tasks {
                 }
 
                 cargo.doc(args).run()?;
+
+                println!();
+                println!(":::: Updating Workspace README...");
+
+                let krates = workspace.krates(&fs)?;
+                let readme_path = workspace.readme.path.clone();
+
+                workspace.readme.update_crates_list(&fs, krates)?;
+
+                println!(":::: Updated: {:?}", readme_path);
+
+                if opts.has("open") {
+                    cmd!("open", readme_path.to_str().unwrap()).run()?;
+                }
 
                 println!(":::: Done!");
                 println!();

--- a/xtask/src/workspace.rs
+++ b/xtask/src/workspace.rs
@@ -64,6 +64,7 @@ impl Workspace {
         cargo
             .create(&krate.path, ["--name", &krate.name, &kind])
             .run()?;
+        krate.changelog.create(fs, &krate.clone())?;
         krate.readme.create(fs, &krate.clone())?;
         krate.toml.create(fs, &krate.clone())?;
         Ok(krate)


### PR DESCRIPTION
## Description

Adds `cargo xtask changelog` task to view unpublished changes for all crates. Updates `cargo xtask crate:add` task to add `CHANGELOG.md` file and `cargo xtask crate:release` to update crate's changelog with relevant commit messages. 


## How to Test

1. Clone and setup this branch locally ([docs](https://github.com/busticated/rusty#installation))
2. Review the "[How to format commits for changelogs](https://github.com/busticated/rusty/blob/47952136c443fd2729c0c8c934f5213406ff6dea/README.md#:~:text=How%20to%20format%20commits%20for%20changelogs)" FAQ item
3. Review available tasks: `cargo xtask --help`
4. List unpublished changes: `cargo xtask changelog`
5. Run a simulated release: `cargo xtask crate:release --dry-run`

**Outcome**

Docs should be clear and helpful, the changelog task should show an accurate list of unpublished changes, and the release task should include updates to `CHANGELOG.md` for each targeted crate. As of now, the changelog task should output:

```
:::: detect-newline-style
* add new version markers to changelog

:::: node-js-release-info
* add new version markers to changelog
* add integration test for .fetch_all()
* lintings
```


## Related / Discussions

https://github.com/busticated/rusty/pull/4


## Completeness

- [x] PR opened :tada:
- [x] Testing instructions have been provided
- [x] Development [How-To's](https://github.com/busticated/rusty#development) have been provided
- [x] Docs have been updated (`cargo xtask doc`)
- [x] Branch is rebased against _target_ (typically `main`)

