### PR TITLE
chore/cleanups

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,8 +27,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Setup Project
         run: cargo xtask setup
-      - name: Run Linter
-        run: cargo xtask lint
       - name: Run Tests & Coverage
-        run: cargo xtask coverage
+        run: cargo xtask ci
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Run `cargo xtask help` to see any other docs-related commands that are available
 
 In order to support automated crate changelog updates, you will need to:
 
-* Commit crate changes separately - e.g. run: `git add -p crates/<name>/*` to stage files, then run `git add -p crates/<other-name>/*` and commit
+* Commit crate changes separately - e.g. run: `git add -p crates/<name>/*` to stage files, then commit
 * Format your commit message like: `[<crate name>] <message>` e.g. `[node-js-release-info] update docs`
 * Commit changes to the workspace itself (including the `xtask` crate) separately without prefixing your commit message
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,21 @@ Run `cargo xtask help` to see any other coverage-related commands that are avail
 </p>
 </details>
 
+<details id="develop-run-spellcheck">
+<summary><b>How to check for spelling errors</b></summary>
+<p>
+
+To find spelling mistakes in source code and docs across the workspace, run:
+
+```
+cargo xtask spellcheck
+```
+
+Run `cargo xtask help` to see any other test-related commands that are available.
+
+</p>
+</details>
+
 <details id="develop-build-docs">
 <summary><b>How to create docs</b></summary>
 <p>

--- a/crates/node-js-release-info/README.md
+++ b/crates/node-js-release-info/README.md
@@ -43,7 +43,7 @@ async fn main() -> Result<(), NodeJSRelInfoError> {
 
 ## Features
 
-Full `json` serialization + deserialization is avaialable via the `json` feature.
+Full `json` serialization + deserialization is available via the `json` feature.
 
 ```shell
 cargo add node-js-release-info --features json

--- a/xtask/src/changelog.rs
+++ b/xtask/src/changelog.rs
@@ -64,28 +64,25 @@ impl Changelog {
         lines.join("\n")
     }
 
-    pub fn update(&mut self, fs: &FS, krate: &Krate, commits: Vec<String>) -> Result<(), DynError> {
-        if commits.is_empty() {
+    pub fn update(&mut self, fs: &FS, krate: &Krate, log: Vec<String>) -> Result<(), DynError> {
+        if log.is_empty() {
             return Ok(());
         }
         self.load()?;
-        let mut log = format!("{}\n{}\n", MARKER_START, MARKER_END);
-        log.push_str(format!("## v{}\n\n", &krate.version).as_str());
-        for msg in commits.iter() {
-            if msg.is_empty() {
-                continue;
+        let mut changes = format!("{}\n{}\n", MARKER_START, MARKER_END);
+        changes.push_str(format!("## v{}\n\n", &krate.version).as_str());
+        for msg in log.iter() {
+            if !msg.is_empty() {
+                changes.push_str(format!("* {}\n", &msg).as_str());
             }
-            let prefix = format!("[{}]", &krate.name);
-            let msg = msg.trim().replace(&prefix, "");
-            log.push_str(format!("* {}\n", &msg).as_str());
         }
-        log.push('\n');
+        changes.push('\n');
         let ptn = format!(r"{}[\s\S]*?{}", MARKER_START, MARKER_END);
         let re = RegexBuilder::new(ptn.as_str())
             .case_insensitive(true)
             .multi_line(true)
             .build()?;
-        let updated = re.replace(&self.text, &log);
+        let updated = re.replace(&self.text, &changes);
         self.text = updated.as_ref().to_owned();
         self.save(fs)
     }

--- a/xtask/src/git.rs
+++ b/xtask/src/git.rs
@@ -71,40 +71,36 @@ impl<'a> Git<'a> {
         self.build_args(["commit", "--message", message.as_ref()], arguments)
     }
 
-    pub fn tag<T, U>(&self, tag: T, arguments: U) -> Expression
-    where
-        T: AsRef<str>,
-        U: IntoIterator,
-        U::Item: Into<OsString>,
-    {
-        let args = self.tag_params(tag, arguments);
-        self.exec_unsafe(args, None)
-    }
-
-    fn tag_params<T, U>(&self, tag: T, arguments: U) -> Vec<OsString>
-    where
-        T: AsRef<str>,
-        U: IntoIterator,
-        U::Item: Into<OsString>,
-    {
-        self.build_args(["tag", tag.as_ref(), "--message", tag.as_ref()], arguments)
-    }
-
-    pub fn get_tags<U>(&self, arguments: U) -> Expression
+    pub fn tag<U>(&self, arguments: U) -> Expression
     where
         U: IntoIterator,
         U::Item: Into<OsString>,
     {
-        let args = self.get_tags_params(arguments);
+        let args = self.tag_params(arguments);
         self.exec_safe(args, None)
     }
 
-    fn get_tags_params<U>(&self, arguments: U) -> Vec<OsString>
+    fn tag_params<U>(&self, arguments: U) -> Vec<OsString>
     where
         U: IntoIterator,
         U::Item: Into<OsString>,
     {
         self.build_args(["tag"], arguments)
+    }
+
+    pub fn create_tag<T>(&self, tag: T) -> Expression
+    where
+        T: AsRef<str>,
+    {
+        let args = self.create_tag_params(tag);
+        self.exec_unsafe(args, None)
+    }
+
+    fn create_tag_params<T>(&self, tag: T) -> Vec<OsString>
+    where
+        T: AsRef<str>,
+    {
+        self.tag_params([tag.as_ref(), "--message", tag.as_ref()])
     }
 
     pub fn todos(&self) -> Expression {
@@ -184,19 +180,16 @@ mod tests {
     fn it_builds_args_for_the_tag_subcommand() {
         let opts = Options::new(vec![], task_flags! {}).unwrap();
         let git = Git::new(&opts);
-        let args = git.tag_params("my tag", ["--one", "--two"]);
-        assert_eq!(
-            args,
-            ["tag", "my tag", "--message", "my tag", "--one", "--two"]
-        );
+        let args = git.tag_params(["--points-at", "HEAD"]);
+        assert_eq!(args, ["tag", "--points-at", "HEAD"]);
     }
 
     #[test]
-    fn it_builds_args_for_getting_tags() {
+    fn it_builds_args_for_creating_a_tag() {
         let opts = Options::new(vec![], task_flags! {}).unwrap();
         let git = Git::new(&opts);
-        let args = git.get_tags_params(["--points-at", "HEAD"]);
-        assert_eq!(args, ["tag", "--points-at", "HEAD"]);
+        let args = git.create_tag_params("my-tag");
+        assert_eq!(args, ["tag", "my-tag", "--message", "my-tag"]);
     }
 
     #[test]

--- a/xtask/src/krate.rs
+++ b/xtask/src/krate.rs
@@ -163,7 +163,7 @@ impl KrateKind {
     pub fn from_path(path: PathBuf) -> Result<KrateKind, DynError> {
         let path = path.join(SRC_DIRNAME).join(LIB_FILENAME);
 
-        if path.try_exists().is_err() {
+        if !path.is_file() {
             return Ok(KrateKind::Binary);
         }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -86,9 +86,9 @@ fn init_tasks() -> Tasks {
             description: "view changelog entries for the next version of all crates".into(),
             flags: task_flags! {},
             run: |_opts, fs, git, _cargo, workspace, _tasks| {
-                println!("::::::::::::::::::::::::::::::::::::");
-                println!(":::: Viewing Upublished Changes ::::");
-                println!("::::::::::::::::::::::::::::::::::::");
+                println!(":::::::::::::::::::::::::::::::::::::");
+                println!(":::: Viewing Unpublished Changes ::::");
+                println!(":::::::::::::::::::::::::::::::::::::");
                 println!();
 
                 let krates = workspace.krates(&fs)?;
@@ -108,11 +108,14 @@ fn init_tasks() -> Tasks {
                     let krate = krates.get(name).unwrap_or_else(|| panic!("Could Not Find Crate: `{}`!", name));
                     let log = git.get_changelog(krate)?;
 
+                    println!(":::: {} [changes: {}]", &krate.name, log.len());
+
                     if log.is_empty() {
+                        println!("\t--- n/a ---");
+                        println!();
                         continue;
                     }
 
-                    println!(":::: {}", &krate.name);
 
                     for l in log.iter() {
                         println!("* {}", l);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -140,6 +140,10 @@ fn init_tasks() -> Tasks {
                 println!();
 
                 tasks
+                    .get("spellcheck")
+                    .unwrap()
+                    .exec(vec![], tasks)?;
+                tasks
                     .get("lint")
                     .unwrap()
                     .exec(vec![], tasks)?;
@@ -508,6 +512,24 @@ fn init_tasks() -> Tasks {
                 cmd!("rustup", "component", "add", "clippy").run()?;
                 cmd!("rustup", "component", "add", "llvm-tools-preview").run()?;
                 cargo.install(["grcov"]).run()?;
+                cargo.install(["typos-cli"]).run()?;
+
+                println!(":::: Done!");
+                println!();
+                Ok(())
+            },
+        },
+        Task {
+            name: "spellcheck".into(),
+            description: "finds spelling mistakes in source code and docs".into(),
+            flags: task_flags! {},
+            run: |_opts, _fs, _git, _cargo, _workspace, _tasks| {
+                println!(":::::::::::::::::::::::::::");
+                println!(":::: Checking Spelling ::::");
+                println!(":::::::::::::::::::::::::::");
+                println!();
+
+                cmd!("typos").run()?;
 
                 println!(":::: Done!");
                 println!();

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -20,7 +20,7 @@ use inquire::required;
 use inquire::validator::Validation as InquireValidation;
 use inquire::{MultiSelect as InquireMultiSelect, Select as InquireSelect, Text as InquireText};
 use regex::RegexBuilder;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::env;
 use std::error::Error;
 
@@ -91,9 +91,9 @@ fn init_tasks() -> Tasks {
                 println!("::::::::::::::::::::::::::::::::::::");
                 println!();
 
-                let mut krates = workspace.krates(&fs)?;
+                let krates = workspace.krates(&fs)?;
                 let tags_text = git.get_tags(["--list", "--sort=v:refname"]).read()?;
-                let mut tags: HashMap<String, String> = HashMap::new();
+                let mut tags: BTreeMap<String, String> = BTreeMap::new();
 
                 for tag in tags_text.lines() {
                     let (name, version) = match tag.split_once('@') {
@@ -105,7 +105,7 @@ fn init_tasks() -> Tasks {
                 }
 
                 for (name, _version) in tags.iter() {
-                    let krate = krates.get_mut(name).unwrap_or_else(|| panic!("Could Not Find Crate: `{}`!", name));
+                    let krate = krates.get(name).unwrap_or_else(|| panic!("Could Not Find Crate: `{}`!", name));
                     let log = git.get_changelog(krate)?;
 
                     if log.is_empty() {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -92,7 +92,7 @@ fn init_tasks() -> Tasks {
                 println!();
 
                 let krates = workspace.krates(&fs)?;
-                let tags_text = git.get_tags(["--list", "--sort=v:refname"]).read()?;
+                let tags_text = git.tag(["--list", "--sort=v:refname"]).read()?;
                 let mut tags: BTreeMap<String, String> = BTreeMap::new();
 
                 for tag in tags_text.lines() {
@@ -319,7 +319,7 @@ fn init_tasks() -> Tasks {
                 println!();
 
                 let krates = workspace.krates(&fs)?;
-                let tag_text = git.get_tags(["--points-at", "HEAD"]).read()?;
+                let tag_text = git.tag(["--points-at", "HEAD"]).read()?;
                 let mut tags = vec![];
 
                 for line in tag_text.lines() {
@@ -394,7 +394,7 @@ fn init_tasks() -> Tasks {
                 git.commit(message, [""]).run()?;
 
                 for tag in tags {
-                    git.tag(tag, [""]).run()?;
+                    git.create_tag(tag).run()?;
                 }
 
                 println!(":::: Done!");

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -358,7 +358,7 @@ fn init_tasks() -> Tasks {
         },
         Task {
             name: "crate:release".into(),
-            description: "prepate crates for publishing".into(),
+            description: "prepare crates for publishing".into(),
             flags: task_flags! {
                 "dry-run" => "run thru steps but do not save changes"
             },

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -226,8 +226,8 @@ fn init_tasks() -> Tasks {
                     cmd!("open", &report).run()?;
                 }
 
-                println!(":::: Done!");
                 println!(":::: Report: {}", report);
+                println!(":::: Done!");
                 println!();
                 Ok(())
             },
@@ -415,8 +415,8 @@ fn init_tasks() -> Tasks {
                 let dist_dir = workspace.path().join("target/release");
                 cargo.build(["--release"]).run()?;
 
-                println!(":::: Done!");
                 println!(":::: Artifacts: {}", dist_dir.display());
+                println!(":::: Done!");
                 println!();
                 Ok(())
             },

--- a/xtask/src/workspace.rs
+++ b/xtask/src/workspace.rs
@@ -61,12 +61,12 @@ impl Workspace {
 
     pub fn add_krate(&self, fs: &FS, cargo: &Cargo, mut krate: Krate) -> Result<Krate, DynError> {
         let kind = krate.kind.to_string();
-        cargo
-            .create(&krate.path, ["--name", &krate.name, &kind])
-            .run()?;
-        krate.changelog.create(fs, &krate.clone())?;
-        krate.readme.create(fs, &krate.clone())?;
-        krate.toml.create(fs, &krate.clone())?;
+        let args = ["--name", &krate.name, &kind];
+        let krate_copy = krate.clone(); // TODO (mirande): deal w/ "cannot borrow as mutable because it is also borrowed as immutable" errors
+        cargo.create(&krate.path, args).run()?;
+        krate.changelog.create(fs, &krate_copy)?;
+        krate.readme.create(fs, &krate_copy)?;
+        krate.toml.create(fs, &krate_copy)?;
         Ok(krate)
     }
 


### PR DESCRIPTION
## Description

Adds `cargo xtask spellcheck` task to find spelling mistakes in source code and docs across the workspace. Cleans up some typos and tunes interfaces and task output. 


## How to Test

1. Clone and setup this branch locally ([docs](https://github.com/busticated/rusty#installation))
2. Review the "[How to check for spelling errors](https://github.com/busticated/rusty/tree/f0047b650ae88bc38b36a3f1f1cb8d0b3a592bfb#development:~:text=How%20to%20check%20for%20spelling%20errors)" How-To item
3. Review available tasks: `cargo xtask --help`
4. Add a typo to a source file and save (see note [here](https://github.com/crate-ci/typos#why-was--not-corrected) and [dictionary](https://github.com/crate-ci/typos/blob/47dd2976043bd5c76a33aa9300b328a176a1d6f7/crates/codespell-dict/assets/dictionary.txt))
5. Check for typos: `cargo xtask spellcheck`
6. Undo your source file edit: `git checkout -- <path-to-file>`

**Outcome**

How-to entry should be clear and helpful, `cargo xtask spellcheck` task should flag "known" typos, code refactors should make sense.


## Related / Discussions

#5 


## Completeness

- [x] PR opened :tada:
- [x] Testing instructions have been provided
- [x] Development [How-To's](https://github.com/busticated/rusty#development) have been provided
- [x] Docs have been updated (`cargo xtask doc`)
- [x] Branch is rebased against _target_ (typically `main`)

